### PR TITLE
Update zc.buildout; add static egg versions; use buildout on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,20 @@ python:
   - "2.7"
 services:
   - couchdb
+addons:
+  apt:
+    packages:
+    - python-dev
+    - libyaml-dev
 before_install:
-  - easy_install -U setuptools
+  - pip install setuptools==7.0
+  - python2 bootstrap.py
 install:
-  - pip install . --use-mirrors
-  - pip install http://op:x9W3jZ@dist.quintagroup.com/op/rfc6266-0.0.6.zip
-before_script:
-  - pip install -r test_requirements.txt --use-mirrors
+  - bin/buildout -N
 script:
-  - nosetests
+  - bin/nosetests
 after_success:
-  - coveralls
+  - bin/coveralls
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 python:
   - "2.7"
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ python:
   - "2.7"
 services:
   - couchdb
-addons:
-  apt:
-    packages:
-    - python-dev
-    - libyaml-dev
 before_install:
   - pip install setuptools==7.0
   - python2 bootstrap.py

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -25,7 +25,10 @@ import tempfile
 
 from optparse import OptionParser
 
-tmpeggs = tempfile.mkdtemp()
+__version__ = '2015-07-01'
+# See zc.buildout's changelog if this version is up to date.
+
+tmpeggs = tempfile.mkdtemp(prefix='bootstrap-')
 
 usage = '''\
 [DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]
@@ -35,13 +38,14 @@ Bootstraps a buildout-based project.
 Simply run this script in a directory containing a buildout.cfg, using the
 Python that you want bin/buildout to use.
 
-Note that by using --find-links to point to local resources, you can keep 
+Note that by using --find-links to point to local resources, you can keep
 this script from going over the network.
 '''
 
 parser = OptionParser(usage=usage)
-parser.add_option("-v", "--version", help="use a specific zc.buildout version")
-
+parser.add_option("--version",
+                  action="store_true", default=False,
+                  help=("Return bootstrap.py version."))
 parser.add_option("-t", "--accept-buildout-test-releases",
                   dest='accept_buildout_test_releases',
                   action="store_true", default=False,
@@ -59,36 +63,57 @@ parser.add_option("-f", "--find-links",
 parser.add_option("--allow-site-packages",
                   action="store_true", default=False,
                   help=("Let bootstrap.py use existing site packages"))
-
+parser.add_option("--buildout-version",
+                  help="Use a specific zc.buildout version")
+parser.add_option("--setuptools-version",
+                  help="Use a specific setuptools version")
+parser.add_option("--setuptools-to-dir",
+                  help=("Allow for re-use of existing directory of "
+                        "setuptools versions"))
 
 options, args = parser.parse_args()
+if options.version:
+    print("bootstrap.py version %s" % __version__)
+    sys.exit(0)
+
 
 ######################################################################
 # load/install setuptools
 
 try:
-    if options.allow_site_packages:
-        import setuptools
-        import pkg_resources
     from urllib.request import urlopen
 except ImportError:
     from urllib2 import urlopen
 
 ez = {}
-exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
+if os.path.exists('ez_setup.py'):
+    exec(open('ez_setup.py').read(), ez)
+else:
+    exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
 
 if not options.allow_site_packages:
     # ez_setup imports site, which adds site packages
-    # this will remove them from the path to ensure that incompatible versions 
+    # this will remove them from the path to ensure that incompatible versions
     # of setuptools are not in the path
     import site
-    # inside a virtualenv, there is no 'getsitepackages'. 
+    # inside a virtualenv, there is no 'getsitepackages'.
     # We can't remove these reliably
     if hasattr(site, 'getsitepackages'):
         for sitepackage_path in site.getsitepackages():
-            sys.path[:] = [x for x in sys.path if sitepackage_path not in x]
+            # Strip all site-packages directories from sys.path that
+            # are not sys.prefix; this is because on Windows
+            # sys.prefix is a site-package directory.
+            if sitepackage_path != sys.prefix:
+                sys.path[:] = [x for x in sys.path
+                               if sitepackage_path not in x]
 
 setup_args = dict(to_dir=tmpeggs, download_delay=0)
+
+if options.setuptools_version is not None:
+    setup_args['version'] = options.setuptools_version
+if options.setuptools_to_dir is not None:
+    setup_args['to_dir'] = options.setuptools_to_dir
+
 ez['use_setuptools'](**setup_args)
 import setuptools
 import pkg_resources
@@ -104,7 +129,12 @@ for path in sys.path:
 
 ws = pkg_resources.working_set
 
+setuptools_path = ws.find(
+    pkg_resources.Requirement.parse('setuptools')).location
+
+# Fix sys.path here as easy_install.pth added before PYTHONPATH
 cmd = [sys.executable, '-c',
+       'import sys; sys.path[0:0] = [%r]; ' % setuptools_path +
        'from setuptools.command.easy_install import main; main()',
        '-mZqNxd', tmpeggs]
 
@@ -117,21 +147,23 @@ find_links = os.environ.get(
 if find_links:
     cmd.extend(['-f', find_links])
 
-setuptools_path = ws.find(
-    pkg_resources.Requirement.parse('setuptools')).location
-
 requirement = 'zc.buildout'
-version = options.version
+version = options.buildout_version
 if version is None and not options.accept_buildout_test_releases:
     # Figure out the most recent final version of zc.buildout.
     import setuptools.package_index
     _final_parts = '*final-', '*final'
 
     def _final_version(parsed_version):
-        for part in parsed_version:
-            if (part[:1] == '*') and (part not in _final_parts):
-                return False
-        return True
+        try:
+            return not parsed_version.is_prerelease
+        except AttributeError:
+            # Older setuptools
+            for part in parsed_version:
+                if (part[:1] == '*') and (part not in _final_parts):
+                    return False
+            return True
+
     index = setuptools.package_index.PackageIndex(
         search_path=[setuptools_path])
     if find_links:
@@ -156,7 +188,7 @@ if version:
 cmd.append(requirement)
 
 import subprocess
-if subprocess.call(cmd, env=dict(os.environ, PYTHONPATH=setuptools_path)) != 0:
+if subprocess.call(cmd) != 0:
     raise Exception(
         "Failed to execute command:\n%s" % repr(cmd)[1:-1])
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -111,6 +111,8 @@ setup_args = dict(to_dir=tmpeggs, download_delay=0)
 
 if options.setuptools_version is not None:
     setup_args['version'] = options.setuptools_version
+else:
+    setup_args['version'] = "7.0"
 if options.setuptools_to_dir is not None:
     setup_args['to_dir'] = options.setuptools_to_dir
 
@@ -148,7 +150,7 @@ if find_links:
     cmd.extend(['-f', find_links])
 
 requirement = 'zc.buildout'
-version = options.buildout_version
+version = options.buildout_version or "2.2.5"
 if version is None and not options.accept_buildout_test_releases:
     # Figure out the most recent final version of zc.buildout.
     import setuptools.package_index

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,7 +1,9 @@
 [buildout]
+extends = versions.cfg
 newest = false
 parts = test
 develop = .
+find-links = http://op:x9W3jZ@dist.quintagroup.com/op/
 
 [test]
 recipe = zc.recipe.egg:scripts

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,3 @@ cover-package=openprocurement.api
 logging-level=INFO
 with-coverage=1
 with-doctest=1
-
-[easy_install]
-find_links = http://op:x9W3jZ@dist.quintagroup.com/op/

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,0 +1,119 @@
+[versions]
+Jinja2 = 2.7.3
+MarkupSafe = 0.23
+PasteDeploy = 1.5.2
+Pygments = 2.0.1
+Sphinx = 1.2.3
+WebOb = 1.4.1
+WebTest = 2.0.18
+docutils = 0.12
+jsonpointer = 1.9
+nose = 1.3.4
+py = 1.4.26
+pyramid = 1.5.7
+python-coveralls = 2.5.0
+repoze.lru = 0.6
+translationstring = 1.3
+venusian = 1.0
+waitress = 0.8.9
+zc.recipe.egg = 2.0.1
+zope.deprecation = 4.1.1
+zope.interface = 4.1.1
+
+# Required by:
+# couchdb-schematics==1.1.1
+CouchDB = 1.0
+
+# Required by:
+# rfc6266==0.0.6
+LEPL = 5.1.3
+
+# Required by:
+# python-coveralls==2.5.0
+PyYAML = 3.11
+
+# Required by:
+# WebTest==2.0.18
+beautifulsoup4 = 4.3.2
+
+# Required by:
+# openprocurement.api==0.8.1
+boto = 2.31.1
+
+# Required by:
+# openprocurement.api==0.8.1
+chaussette = 1.2
+
+# Required by:
+# openprocurement.api==0.8.1
+cornice = 1.0.0
+
+# Required by:
+# openprocurement.api==0.8.1
+couchdb-schematics = 1.1.1
+
+# Required by:
+# openprocurement.api==0.8.1
+gevent = 1.0.1
+
+# Required by:
+# gevent==1.0.1
+greenlet = 0.4.5
+
+# Required by:
+# openprocurement.api==0.8.1
+iso8601 = 0.1.10
+
+# Required by:
+# openprocurement.api==0.8.1
+jsonpatch = 1.9op1
+
+# Required by:
+# openprocurement.api==0.8.1
+pbkdf2 = 1.3
+
+# Required by:
+# openprocurement.api==0.8.1
+pyramid-exclog = 0.7
+
+# Required by:
+# couchdb-schematics==1.1.1
+pytest = 2.6.4
+
+# Required by:
+# tzlocal==1.1.2
+pytz = 2014.10
+
+# Required by:
+# python-coveralls==2.5.0
+requests = 2.7.0
+
+# Required by:
+# openprocurement.api==0.8.1
+rfc6266 = 0.0.6
+
+# Required by:
+# couchdb-schematics==1.1.1
+schematics = 1.0.4
+
+# Required by:
+# python-coveralls==2.5.0
+sh = 1.11
+
+# Required by:
+# cornice==1.0.0
+simplejson = 3.6.5
+
+# Required by:
+# WebTest==2.0.18
+# python-coveralls==2.5.0
+# sphinxcontrib-httpdomain==1.3.0
+six = 1.9.0
+
+# Required by:
+# openprocurement.api==0.8.1
+sphinxcontrib-httpdomain = 1.3.0
+
+# Required by:
+# openprocurement.api==0.8.1
+tzlocal = 1.1.2


### PR DESCRIPTION
This is also needed to fix the following issue: https://github.com/openprocurement/openprocurement.buildout/pull/1