### PR TITLE
Прибрав неявну роботу з глобальною областю видимості

### DIFF
--- a/src/openprocurement/api/design.py
+++ b/src/openprocurement/api/design.py
@@ -34,11 +34,6 @@ def add_index_options(doc):
     doc['options'] = {'local_seq': True}
 
 
-def sync_design(db):
-    views = [j for i, j in globals().items() if "_view" in i]
-    ViewDefinition.sync_many(db, views, callback=add_index_options)
-
-
 tenders_all_view = ViewDefinition('tenders', 'all', '''function(doc) {
     if(doc.doc_type == 'Tender') {
         emit(doc.tenderID, null);
@@ -123,3 +118,13 @@ conflicts_view = ViewDefinition('conflicts', 'all', '''function(doc) {
         emit(doc._rev, [doc._rev].concat(doc._conflicts));
     }
 }''')
+
+
+design_list = [tenders_all_view, tenders_by_dateModified_view, tenders_real_by_dateModified_view,
+               tenders_test_by_dateModified_view, tenders_by_local_seq_view,
+               tenders_real_by_local_seq_view, tenders_test_by_local_seq_view,
+               conflicts_view]
+
+
+def sync_design(db):
+    ViewDefinition.sync_many(db, design_list, callback=add_index_options)

--- a/src/openprocurement/api/design.py
+++ b/src/openprocurement/api/design.py
@@ -128,7 +128,3 @@ design_list = [tenders_all_view, tenders_by_dateModified_view, tenders_real_by_d
 
 def sync_design(db):
     ViewDefinition.sync_many(db, design_list, callback=add_index_options)
-
-
-def add_to_design_list(new_designs):
-        design_list.extend(new_designs)

--- a/src/openprocurement/api/design.py
+++ b/src/openprocurement/api/design.py
@@ -128,3 +128,7 @@ design_list = [tenders_all_view, tenders_by_dateModified_view, tenders_real_by_d
 
 def sync_design(db):
     ViewDefinition.sync_many(db, design_list, callback=add_index_options)
+
+
+def add_to_design_list(new_designs):
+        design_list.extend(new_designs)


### PR DESCRIPTION
Потрібно мати можливість розширити design views, з інших модулів(на зразок як в https://github.com/openprocurement/openprocurement.planning.api/blob/master/openprocurement/planning/api/design.py). Тому я переніс всі вьюхи в список, який можливо розшири до запуску.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.api/88)
<!-- Reviewable:end -->
