### PR TITLE
Don`t change owner for cd role

### DIFF
--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -201,8 +201,7 @@ def get_revision_changes(dst, src):
 
 
 def set_ownership(item, request):
-    # for competitive dialogue bridge role should not change tender owner
-    if request.authenticated_role != 'competitive_dialogue':
+    if not item.get('owner'):
         item.owner = request.authenticated_userid
     item.owner_token = generate_id()
 

--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -201,7 +201,9 @@ def get_revision_changes(dst, src):
 
 
 def set_ownership(item, request):
-    item.owner = request.authenticated_userid
+    # for competitive dialogue bridge role should not change tender owner
+    if request.authenticated_role != 'competitive_dialogue':
+        item.owner = request.authenticated_userid
     item.owner_token = generate_id()
 
 


### PR DESCRIPTION
Необхідна зміна для успішного породження тендеру 2 етапу (без цього неможливо отримати токен через /credentials, так як owner перебивається userid мосту).
Необхідно для https://github.com/openprocurement/openprocurement.tender.competitivedialogue/pull/9
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.api/99)
<!-- Reviewable:end -->
