### PR TITLE
can change tenderID

### DIFF
--- a/src/openprocurement/api/views/tender.py
+++ b/src/openprocurement/api/views/tender.py
@@ -347,7 +347,8 @@ class TendersResource(APIResource):
         tender_id = generate_id()
         tender = self.request.validated['tender']
         tender.id = tender_id
-        tender.tenderID = generate_tender_id(get_now(), self.db, self.server_id)
+        if not tender.get('tenderID'):
+            tender.tenderID = generate_tender_id(get_now(), self.db, self.server_id)
         if hasattr(tender, "initialize"):
             tender.initialize()
         if self.request.json_body['data'].get('status') == 'draft':


### PR DESCRIPTION
Можливість зміни поля tenderID  при створенні мостом для конкурентного діалогу (tenderID для другого етапу повинен формуватися як tenderID першого + '.2' )
Так як поле tenderID присутнє у blacklist ролі 'create' для всіх процедур - вказана правка наче не нашкодить.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.api/104)
<!-- Reviewable:end -->
