### PR TITLE
Set tender status complete

### DIFF
--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -430,11 +430,12 @@ def check_tender_status(request):
                 LOGGER.info('Switched lot {} of tender {} to {}'.format(lot.id, tender.id, 'complete'),
                             extra=context_unpack(request, {'MESSAGE_ID': 'switched_lot_complete'}, {'LOT_ID': lot.id}))
                 lot.status = 'complete'
+        merged_lots_ids = [get_award_by_id(tender, contract['awardID'])['lotID']
+                           for contract in tender.contracts
+                           if contract.status == 'merged']
         statuses = set([lot.status
                         for lot in tender.lots
-                        if lot.id not in [get_award_by_id(tender, contract['awardID'])['lotID']
-                                          for contract in tender.contracts
-                                          if contract.status == 'merged']])
+                        if lot.id not in merged_lots_ids])
         if statuses == set(['cancelled']):
             LOGGER.info('Switched tender {} to {}'.format(tender.id, 'cancelled'),
                         extra=context_unpack(request, {'MESSAGE_ID': 'switched_tender_cancelled'}))


### PR DESCRIPTION
З списку statuses треба виключати лоти контракти яких в статусі merged.

PS: Є альтернатива реалізація, коли контракт переходить в статус 'merged' переводити лот в статус 'merged' теж, але це більшь глобальне втручання.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.api/122)

<!-- Reviewable:end -->
