### PR TITLE
Merged contracts amount validation

### DIFF
--- a/src/openprocurement/api/tests/award.py
+++ b/src/openprocurement/api/tests/award.py
@@ -638,6 +638,50 @@ class Tender2LotAwardResourceTest(BaseTenderWebTest):
         self.assertEqual(response.content_type, 'application/json')
         self.assertEqual(response.json['errors'][0]["description"], "Can update award only in active lot status")
 
+    def test_cancel_merged_award(self):
+        # Create first award
+        request_path = '/tenders/{}/awards'.format(self.tender_id)
+        response = self.app.post_json(request_path, {'data': {'suppliers': [test_organization], 'status': u'pending',
+                                                              'bid_id': self.initial_bids[0]['id'],
+                                                              'lotID': self.initial_lots[0]['id'], "value": {"amount": 500}}})
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+        first_award = response.json['data']
+
+        response = self.app.patch_json('/tenders/{}/awards/{}'.format(self.tender_id, first_award['id']), {"data": {"status": "active"}})
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.content_type, 'application/json')
+        self.assertEqual(response.json['data']['status'], 'active')
+
+        # Create second award
+        request_path = '/tenders/{}/awards'.format(self.tender_id)
+        response = self.app.post_json(request_path, {'data': {'suppliers': [test_organization], 'status': u'pending',
+                                                              'bid_id': self.initial_bids[0]['id'],
+                                                              'lotID': self.initial_lots[0]['id'], "value": {"amount": 500}}})
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+        second_award = response.json['data']
+
+        response = self.app.patch_json('/tenders/{}/awards/{}'.format(self.tender_id, second_award['id']), {"data": {"status": "active"}})
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.content_type, 'application/json')
+        self.assertEqual(response.json['data']['status'], 'active')
+
+        # Merge contract
+        response = self.app.get('/tenders/{}/contracts'.format(self.tender_id))
+        response = self.app.patch_json('/tenders/{}/contracts/{}?acc_token={}'.format(
+            self.tender_id, response.json['data'][0]['id'], self.tender_token),
+            {"data": {"additionalAwardIDs": [response.json['data'][1]['awardID']]}})
+
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.content_type, 'application/json')
+
+        # Try to cancel second award
+        response = self.app.patch_json('/tenders/{}/awards/{}'.format(self.tender_id, second_award['id']),
+                                       {"data": {"status": "cancelled"}}, status=403)
+        self.assertEqual(response.status, '403 Forbidden')
+        self.assertEqual(response.json['errors'][0]["description"], "Can\'t cancel award while it is a part of merged contracts.")
+
 
 class TenderAwardComplaintResourceTest(BaseTenderWebTest):
     #initial_data = tender_data

--- a/src/openprocurement/api/tests/cancellation.py
+++ b/src/openprocurement/api/tests/cancellation.py
@@ -454,7 +454,7 @@ class TenderLotCancellationContractTest(BaseTenderWebTest):
         self.assertEqual(response.json['errors'][0]["description"],
                          "Can add cancellation on lot if corresponding contract is merged.")
 
-    def test_create_cancellation_on_lot_with_cancalled_awards(self):
+    def test_create_cancellation_on_lot_with_cancelled_awards(self):
         """ Try create cancellation when we already have cancelled award """
         # Create awards
         request_path = '/tenders/{}/awards'.format(self.tender_id)

--- a/src/openprocurement/api/tests/cancellation.py
+++ b/src/openprocurement/api/tests/cancellation.py
@@ -454,6 +454,75 @@ class TenderLotCancellationContractTest(BaseTenderWebTest):
         self.assertEqual(response.json['errors'][0]["description"],
                          "Can add cancellation on lot if corresponding contract is merged.")
 
+    def test_create_cancellation_on_lot_with_cancalled_awards(self):
+        """ Try create cancellation when we already have cancelled award """
+        # Create awards
+        request_path = '/tenders/{}/awards'.format(self.tender_id)
+        response = self.app.post_json(request_path, {'data': {'suppliers': [test_organization],
+                                                              'status': u'pending',
+                                                              'bid_id': self.initial_bids[0]['id'],
+                                                              'lotID': self.initial_lots[0]['id'],
+                                                              'value': {"amount": 500}}})
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+        first_award = response.json['data']
+        response = self.app.post_json(request_path, {'data': {'suppliers': [test_organization],
+                                                              'status': u'pending',
+                                                              'bid_id': self.initial_bids[1]['id'],
+                                                              'lotID': self.initial_lots[1]['id'],
+                                                              "value": {"amount": 500}}})
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+        second_award = response.json['data']
+        response = self.app.patch_json(
+            '/tenders/{}/awards/{}'.format(self.tender_id, first_award['id']),
+            {"data": {"status": "active"}})
+        self.assertEqual(response.json['data']['status'], 'active')
+        response = self.app.patch_json(
+            '/tenders/{}/awards/{}'.format(self.tender_id, second_award['id']),
+            {"data": {"status": "active"}})
+        self.assertEqual(response.json['data']['status'], 'active')
+
+        # Cancel first award
+        response = self.app.patch_json(
+            '/tenders/{}/awards/{}'.format(self.tender_id, first_award['id']),
+            {"data": {"status": "cancelled"}})
+        self.assertEqual(response.json['data']['status'], 'cancelled')
+
+        # Check number awards
+        awards = self.app.get('/tenders/{}/awards?acc_token={}'.format(self.tender_id, self.tender_token))
+        self.assertEqual(len(awards.json['data']), 3)
+
+        # Get new award
+        new_awards = [award for award in awards.json['data']
+                      if award['lotID'] == self.initial_lots[0]['id']
+                      and award['status'] == 'pending']
+        self.assertEqual(len(new_awards), 1)
+        new_award = new_awards[0]
+
+        # Active and merge new award
+        response = self.app.patch_json('/tenders/{}/awards/{}?acc_token={}'.format(
+            self.tender_id, new_award['id'], self.tender_token),
+            {'data': {'status': 'active'}})
+        third_award = response.json['data']
+
+        response = self.app.get('/tenders/{}/contracts'.format(self.tender_id))
+        second_contract = [c for c in response.json['data'] if c['awardID'] == second_award['id']][0]
+        response = self.app.patch_json('/tenders/{}/contracts/{}?acc_token={}'.format(
+            self.tender_id, second_contract['id'], self.tender_token),
+            {"data": {"additionalAwardIDs": [third_award['id']]}})
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.content_type, 'application/json')
+
+        # Create cancellation on lot
+        response = self.app.post_json('/tenders/{}/cancellations'.format(self.tender_id),
+            {"data": {"reason": "cancellation reason",
+                      "cancellationOf": "lot",
+                      "relatedLot": third_award['lotID']}}, status=403)
+        self.assertEqual(response.status, '403 Forbidden')
+        self.assertEqual(response.json['errors'][0]["description"],
+                         "Can add cancellation on lot if corresponding contract is merged.")
+
     def test_update_lot_cancellation_on_merged_contract(self):
         second_lot_id = self.initial_lots[1]['id']
 

--- a/src/openprocurement/api/views/award.py
+++ b/src/openprocurement/api/views/award.py
@@ -337,7 +337,7 @@ class TenderAwardResource(APIResource):
                                  if contract['awardID'] in i['additionalAwardIDs']))
                     del i['additionalAwardIDs']  # delete additionalAwardIDs from cancelled contract
                     i.status = 'cancelled'
-                break
+                    break
             add_next_award(self.request)
         elif award_status == 'pending' and award.status == 'unsuccessful':
             award.complaintPeriod.endDate = calculate_business_date(get_now(), STAND_STILL_TIME, tender, True)

--- a/src/openprocurement/api/views/cancellation.py
+++ b/src/openprocurement/api/views/cancellation.py
@@ -59,8 +59,8 @@ class TenderCancellationResource(APIResource):
             self.request.errors.add('body', 'data', 'Can {} cancellation only in active lot status'.format(operation))
             self.request.errors.status = 403
             return
-        award_id = tender.get('awards') and [i.id for i in tender.awards if i.lotID == cancellation.relatedLot][0] or False
-        if cancellation.get('relatedLot') and award_id and [c for c in tender.get('contracts') if c.awardID == award_id and c.status == 'merged']:
+        awards_id = [i.id for i in tender.awards if i.lotID == cancellation.relatedLot] if tender.get('awards') else False
+        if cancellation.get('relatedLot') and [c for c in tender.get('contracts') if c.awardID in awards_id and c.status == 'merged']:
             self.request.errors.add('body', 'data', 'Can {} cancellation on lot if corresponding contract is merged.'.format(operation))
             self.request.errors.status = 403
             return

--- a/src/openprocurement/api/views/cancellation.py
+++ b/src/openprocurement/api/views/cancellation.py
@@ -59,6 +59,11 @@ class TenderCancellationResource(APIResource):
             self.request.errors.add('body', 'data', 'Can {} cancellation only in active lot status'.format(operation))
             self.request.errors.status = 403
             return
+        award_id = tender.get('awards') and [i.id for i in tender.awards if i.lotID == cancellation.relatedLot][0] or False
+        if cancellation.get('relatedLot') and award_id and [c for c in tender.get('contracts') if c.awardID == award_id and c.status == 'merged']:
+            self.request.errors.add('body', 'data', 'Can {} cancellation on lot if corresponding contract is merged.'.format(operation))
+            self.request.errors.status = 403
+            return
         return True
 
     @json_view(content_type="application/json", validators=(validate_cancellation_data,), permission='edit_tender')


### PR DESCRIPTION
- [x] контроль запису value залишається за майданчиками; окрім скасування award (переведення його в cancelled), у користувача буде можливість від’єднати учасника від об’єднаного контракту - майданчик при цьому перезаписуватиме additionalAwardIDs, прибираючи з нього ID відповідного award (контракт, який був на цьому award у статусі merged, повертатиметься до pending - я правильно зрозуміла?)

- [x]  не можна скасовувати award, поки він є частиною об’єднаного контракту  

- [x] не можна активувати (а краще - створювати навіть у pending) об’єкт cancellation на лот, award котрого є серед тих, що в об’єднаному контракті (серед його additionalAwardIDs)

- [x] при отриманні скарги у статусі satisfied на award, який є в об’єднаному контракті, має реплікуватись поведінка, яка зараз є на ЦБД: користувач скасовує такий award, це автоматично переводить в статус cancelled  всі award(и), статус яких вже було змінено (active та unsuccessful). решта поведінки ідентична тій, яка йде при скасуванні award: його ID виключається з additionalAwardIDs об’єднаного контракту, контракт, який був merged, переходить в cancelled, value об’єднаного контракту перезаписується майданчиком (віднімаючи суму пропозиції скасованого award)

- [x] на ЦБД залишається контроль неперевищення value об’єднаного контракту суми об’єдниних пропозицій (award–ів)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.api/151)
<!-- Reviewable:end -->
