### PR TITLE
Add `_meta` field to Award model

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -4,7 +4,7 @@ newest = false
 parts = test
 develop = .
 find-links = http://op:x9W3jZ@dist.quintagroup.com/op/
-index = http://pypi.python.org/simple
+index = https://pypi.python.org/simple
 
 [test]
 recipe = zc.recipe.egg:scripts

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -4,6 +4,7 @@ newest = false
 parts = test
 develop = .
 find-links = http://op:x9W3jZ@dist.quintagroup.com/op/
+index = http://pypi.python.org/simple
 
 [test]
 recipe = zc.recipe.egg:scripts

--- a/setup.py
+++ b/setup.py
@@ -70,3 +70,4 @@ setup(name='openprocurement.api',
       extras_require={'test': test_requires, 'docs': docs_requires},
       test_suite="openprocurement.api.tests.main.suite",
       entry_points=entry_points)
+

--- a/src/openprocurement/api/models.py
+++ b/src/openprocurement/api/models.py
@@ -9,8 +9,13 @@ from pyramid.security import Allow
 from schematics.exceptions import ConversionError, ValidationError
 from schematics.models import Model as SchematicsModel
 from schematics.transforms import whitelist, blacklist, export_loop, convert
-from schematics.types import StringType, FloatType, IntType, URLType, BooleanType, BaseType, EmailType, MD5Type, DecimalType as BaseDecimalType
-from schematics.types.compound import ModelType, DictType, ListType as BaseListType
+from schematics.types import (
+    StringType, FloatType, IntType, URLType, BooleanType, BaseType, EmailType,
+    MD5Type, DecimalType as BaseDecimalType
+)
+from schematics.types.compound import (
+    ModelType, DictType, ListType as BaseListType
+)
 from schematics.types.serializable import serializable
 from uuid import uuid4
 from barbecue import vnmax
@@ -943,11 +948,16 @@ class Award(Model):
     """
     class Options:
         roles = {
-            'create': blacklist('id', 'status', 'date', 'documents', 'complaints', 'complaintPeriod'),
-            'edit': whitelist('status', 'title', 'title_en', 'title_ru',
-                              'description', 'description_en', 'description_ru'),
+            'create': blacklist(
+                'id', 'status', 'date', 'documents',
+                'complaints', 'complaintPeriod'
+            ),
+            'edit': whitelist(
+                'status', 'title', 'title_en', 'title_ru',
+                'description', 'description_en', 'description_ru'
+            ),
             'embedded': schematics_embedded_role,
-            'view': schematics_default_role,
+            'view': schematics_default_role + blacklist('_meta'),
             'Administrator': whitelist('complaintPeriod'),
         }
 
@@ -968,6 +978,7 @@ class Award(Model):
     documents = ListType(ModelType(Document), default=list())
     complaints = ListType(ModelType(Complaint), default=list())
     complaintPeriod = ModelType(Period)
+    _meta = DictType(StringType)
 
     def validate_lotID(self, data, lotID):
         if isinstance(data['__parent__'], Model):

--- a/src/openprocurement/api/models.py
+++ b/src/openprocurement/api/models.py
@@ -30,9 +30,15 @@ BIDDER_TIME = timedelta(minutes=6)
 SERVICE_TIME = timedelta(minutes=9)
 AUCTION_STAND_STILL_TIME = timedelta(minutes=15)
 SANDBOX_MODE = os.environ.get('SANDBOX_MODE', False)
+AWAILABLE_AWARDING_TYPE = [
+    'awarding_1_0',
+    'awarding_2_0',
+]
 
-schematics_embedded_role = SchematicsDocument.Options.roles['embedded'] + blacklist("__parent__")
-schematics_default_role = SchematicsDocument.Options.roles['default'] + blacklist("__parent__")
+schematics_embedded_role = SchematicsDocument.Options.roles['embedded'] + \
+    blacklist("__parent__")
+schematics_default_role = SchematicsDocument.Options.roles['default'] + \
+    blacklist("__parent__", "_meta")
 
 TZ = timezone(os.environ['TZ'] if 'TZ' in os.environ else 'Europe/Kiev')
 
@@ -941,6 +947,22 @@ class Contract(Model):
                 raise ValidationError(u"Contract signature date can't be in the future")
 
 
+class AwardMetadata(Model):
+
+    _awarding_type = StringType(default='')
+
+    @property
+    def awarding_type(self):
+        return self._awarding_type
+
+    @awarding_type.setter
+    def awarding_type(self, value):
+        if value in AWAILABLE_AWARDING_TYPE:
+            self._awarding_type = value
+        else:
+            raise ValueError('Invalid awarding type')
+
+
 class Award(Model):
     """ An award for the given procurement. There may be more than one award
         per contracting process e.g. because the contract is split amongst
@@ -957,7 +979,7 @@ class Award(Model):
                 'description', 'description_en', 'description_ru'
             ),
             'embedded': schematics_embedded_role,
-            'view': schematics_default_role + blacklist('_meta'),
+            'view': schematics_default_role,
             'Administrator': whitelist('complaintPeriod'),
         }
 
@@ -978,7 +1000,7 @@ class Award(Model):
     documents = ListType(ModelType(Document), default=list())
     complaints = ListType(ModelType(Complaint), default=list())
     complaintPeriod = ModelType(Period)
-    _meta = DictType(StringType)
+    _meta = ModelType(AwardMetadata)
 
     def validate_lotID(self, data, lotID):
         if isinstance(data['__parent__'], Model):

--- a/src/openprocurement/api/tests/award.py
+++ b/src/openprocurement/api/tests/award.py
@@ -1,7 +1,18 @@
 # -*- coding: utf-8 -*-
 import unittest
 
-from openprocurement.api.tests.base import BaseTenderWebTest, test_tender_data, test_bids, test_lots, test_organization
+from openprocurement.api.tests.base import (
+    BaseTenderWebTest,
+    test_tender_data,
+    test_bids,
+    test_lots,
+    test_organization
+)
+from openprocurement.api.models import (
+    Award,
+    AwardMetadata,
+    AWAILABLE_AWARDING_TYPE
+)
 
 
 class TenderAwardResourceTest(BaseTenderWebTest):
@@ -2460,16 +2471,23 @@ class AwardModelTest(unittest.TestCase):
     """Test hidden `_meta` field of Award model"""
 
     def test_meta_field_visibility(self):
-        from openprocurement.api.models import Award
         award = Award()
-        award._meta = {
-            'awardingType': 'awarding_1_0',
-            'foo': {
-                'bar': 'some metadata'
-            }
-        }
+        metadata = AwardMetadata()
+        award._meta = metadata
+        self.assertEqual(award._meta.awarding_type, '')
         primitive_award = award.serialize('view')
         self.assertNotIn('_meta', primitive_award)
+
+class MetadataModelTest(unittest.TestCase):
+
+    def test_wrong_awarding_type_set(self):
+        meta = AwardMetadata()
+        with self.assertRaises(ValueError) as context:
+            meta.awarding_type = 'blabla-2/0'
+
+    def test_good_awarding_type_set(self):
+        meta = AwardMetadata()
+        meta.awarding_type = AWAILABLE_AWARDING_TYPE[0]
 
 
 def suite():
@@ -2484,6 +2502,7 @@ def suite():
     suite.addTest(unittest.makeSuite(TenderAwardResourceTest))
     suite.addTest(unittest.makeSuite(TenderLotAwardResourceTest))
     suite.addTest(unittest.makeSuite(AwardModelTest))
+    suite.addTest(unittest.makeSuite(MetadataModelTest))
     return suite
 
 

--- a/src/openprocurement/api/tests/award.py
+++ b/src/openprocurement/api/tests/award.py
@@ -2456,6 +2456,22 @@ class Tender2LotAwardDocumentWithDSResourceTest(Tender2LotAwardDocumentResourceT
     docservice = True
 
 
+class AwardModelTest(unittest.TestCase):
+    """Test hidden `_meta` field of Award model"""
+
+    def test_meta_field_visibility(self):
+        from openprocurement.api.models import Award
+        award = Award()
+        award._meta = {
+            'awardingType': 'awarding_1_0',
+            'foo': {
+                'bar': 'some metadata'
+            }
+        }
+        primitive_award = award.serialize('view')
+        self.assertNotIn('_meta', primitive_award)
+
+
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(Tender2LotAwardComplaintDocumentResourceTest))
@@ -2467,8 +2483,10 @@ def suite():
     suite.addTest(unittest.makeSuite(TenderAwardDocumentResourceTest))
     suite.addTest(unittest.makeSuite(TenderAwardResourceTest))
     suite.addTest(unittest.makeSuite(TenderLotAwardResourceTest))
+    suite.addTest(unittest.makeSuite(AwardModelTest))
     return suite
 
 
 if __name__ == '__main__':
     unittest.main(defaultTest='suite')
+


### PR DESCRIPTION
Due to multiple awarding procedures existance, there is a need
to mark particular award instance somehow to use proper logic
for them.

For this purpose field `_meta` is added. It's blacklisted from
appearance in views, that's why it's expandable enough to store
additional metadata.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.api/253)
<!-- Reviewable:end -->
