### PR TITLE
Add route predicate `awardingType`

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -4,6 +4,7 @@ newest = false
 parts = test
 develop = .
 find-links = http://op:x9W3jZ@dist.quintagroup.com/op/
+index = https://pypi.python.org/simple
 
 [test]
 recipe = zc.recipe.egg:scripts

--- a/src/openprocurement/api/__init__.py
+++ b/src/openprocurement/api/__init__.py
@@ -23,6 +23,7 @@ from openprocurement.api.utils import (
     extract_tender,
     request_params,
     isTender,
+    awardingTypePredicate,
     set_renderer,
     beforerender,
     register_tender_procurementMethodType,
@@ -100,6 +101,7 @@ def main(global_config, **settings):
 
     # tender procurementMethodType plugins support
     config.add_route_predicate('procurementMethodType', isTender)
+    config.add_route_predicate('awardingType', awardingTypePredicate)
     config.registry.tender_procurementMethodTypes = {}
     config.add_request_method(tender_from_data)
     config.add_directive('add_tender_procurementMethodType', register_tender_procurementMethodType)

--- a/src/openprocurement/api/constants.py
+++ b/src/openprocurement/api/constants.py
@@ -1,0 +1,7 @@
+AWARDING_OF_PROCUREMENT_METHOD_TYPE = {
+    'belowThreshold': 'awarding_1_0',
+    'dgfFinancialAssets': 'awarding_2_0',
+    'dgfOtherAssets': 'awarding_2_0',
+    'dgfInsider': 'awarding_2_0',
+}
+

--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -15,7 +15,11 @@ from json import dumps
 from jsonpatch import make_patch, apply_patch as _apply_patch
 from jsonpointer import resolve_pointer
 from logging import getLogger
-from openprocurement.api.models import get_now, TZ, COMPLAINT_STAND_STILL_TIME, WORKING_DAYS
+from openprocurement.api.models import (
+    get_now, TZ,
+    COMPLAINT_STAND_STILL_TIME,
+    WORKING_DAYS
+)
 from openprocurement.api.traversal import factory
 from pkg_resources import get_distribution
 from rfc6266 import build_header
@@ -32,6 +36,7 @@ from Crypto.Cipher import AES
 from re import compile
 from requests import Session
 from openprocurement.api.interfaces import IContentConfigurator
+from openprocurement.api.constants import AWARDING_OF_PROCUREMENT_METHOD_TYPE
 
 
 PKG = get_distribution(__package__)
@@ -808,6 +813,34 @@ class isTender(object):
     def __call__(self, context, request):
         if request.tender is not None:
             return getattr(request.tender, 'procurementMethodType', None) == self.val
+        return False
+
+
+class awardingTypePredicate(object):
+    def __init__(self, val, config):
+        self.val = val
+
+    def text(self):
+        return 'awardingType = {value}'.format(value=self.val)
+
+    phash = text
+
+    def __call__(self, context, request):
+        if request.auction is not None:
+            procurement_method_type = getattr(
+                request.auction,
+                'procurementMethodType',
+                None
+            )
+            if not procurement_method_type:
+                return False
+
+            desirable_awarding_version = \
+                AWARDING_OF_PROCUREMENT_METHOD_TYPE.get(
+                    procurement_method_type
+                )
+            return desirable_awarding_version == self.val
+
         return False
 
 


### PR DESCRIPTION
There are two awailable awarding procedures and more than two auction
procedures. Due to this awarding views have redundant `opresource`
decorators. This route predicate added for make routing to awarding
views more straightforward.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.api/255)
<!-- Reviewable:end -->
