### PR TITLE
Add util for search awarding type

### DIFF
--- a/src/openprocurement/api/tests/main.py
+++ b/src/openprocurement/api/tests/main.py
@@ -2,7 +2,19 @@
 
 import unittest
 
-from openprocurement.api.tests import auction, auth, award, bidder, document, migration, spore, tender, question, complaint
+from openprocurement.api.tests import (
+    auction,
+    auth,
+    award,
+    bidder,
+    document,
+    migration,
+    spore,
+    tender,
+    question,
+    complaint,
+    utils,
+)
 
 
 def suite():
@@ -17,8 +29,10 @@ def suite():
     suite.addTest(question.suite())
     suite.addTest(spore.suite())
     suite.addTest(tender.suite())
+    suite.addTest(utils.suite())
     return suite
 
 
 if __name__ == '__main__':
     unittest.main(defaultTest='suite')
+

--- a/src/openprocurement/api/tests/utils.py
+++ b/src/openprocurement/api/tests/utils.py
@@ -1,0 +1,23 @@
+from unittest import TestCase
+
+from openprocurement.api.constants import AWARDING_OF_PROCUREMENT_METHOD_TYPE
+from openprocurement.api.utils import (
+    get_awarding_type_by_procurement_method_type
+)
+
+
+class TestCoreUtils(TestCase):
+
+    def test_get_awarding_type_by_procurement_method_type(self):
+        for key in AWARDING_OF_PROCUREMENT_METHOD_TYPE.keys():
+            awarding_type = get_awarding_type_by_procurement_method_type(key)
+            self.assertEqual(
+                awarding_type,
+                AWARDING_OF_PROCUREMENT_METHOD_TYPE[key],
+                'Awarding type was resolved wrong'
+            )
+
+    def test_get_awarding_type_by_procurement_method_type_raises(self):
+        with self.assertRaises(ValueError) as context:
+            get_awarding_type_by_procurement_method_type('jdfvhdlkjv')
+

--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -963,3 +963,11 @@ def couchdb_json_decode():
         return simplejson.loads(string_, parse_float=decimal.Decimal)
 
     couchdb.json.use(decode=my_decode, encode=my_encode)
+
+
+def get_awarding_type_by_procurement_method_type(procurement_method_type):
+    awarding_type = AWARDING_OF_PROCUREMENT_METHOD_TYPE.get(procurement_method_type)
+    if not awarding_type:
+        raise ValueError
+    return awarding_type
+


### PR DESCRIPTION
The purpose of this util is hiding realization of relations
between procurement method type and awarding type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.api/256)
<!-- Reviewable:end -->
