### PR TITLE
add logging and validation for initialization of authentiocation

### DIFF
--- a/src/openprocurement/api/auth.py
+++ b/src/openprocurement/api/auth.py
@@ -34,7 +34,7 @@ def _file_auth(app_meta):
         return users
 
     config.read(file_path)
-    if not len(config.sections()):
+    if config.sections():
         LOGGER.warning("Auth file '%s' was empty, no user will be added",
                        file_path)
     for item in config.sections():

--- a/src/openprocurement/api/auth.py
+++ b/src/openprocurement/api/auth.py
@@ -26,6 +26,7 @@ def auth(auth_type=None):
 def _void_auth(app_meta):
     return {}
 
+
 @auth(auth_type="file")
 def _file_auth(app_meta):
     conf_auth = app_meta(('config', 'auth'))

--- a/src/openprocurement/api/auth.py
+++ b/src/openprocurement/api/auth.py
@@ -29,10 +29,10 @@ def _file_auth(app_meta):
     file_path = os.path.join(app_meta(['here']), conf_auth.get('src', None))
     users = {}
     if not os.path.isfile(file_path):
-        LOGGER.warning("Auth file '%s' was doesn`t exist, no user will be added",
+        LOGGER.warning("Auth file '%s' was doesn`t exist,"
+                       "no user will be added",
                        file_path)
         return users
-
     config.read(file_path)
     if config.sections():
         LOGGER.warning("Auth file '%s' was empty, no user will be added",
@@ -47,9 +47,11 @@ def _file_auth(app_meta):
             single_key = value.split(',', 1)[0]
             user = {single_key: single_value}
             users.update(user)
-            LOGGER.debug("Authenticate permission for the user %s has been added",
+            LOGGER.debug("Authenticate permission for the user %s"
+                         "has been added",
                          single_key)
-        LOGGER.info("Authentication permissions for users from the section [%s] has been added",
+        LOGGER.info("Authentication permissions for users from the section "
+                    "[%s] has been added",
                     item)
     return users
 

--- a/src/openprocurement/api/auth.py
+++ b/src/openprocurement/api/auth.py
@@ -22,6 +22,10 @@ def auth(auth_type=None):
     return decorator
 
 
+@auth(auth_type="void")
+def _void_auth(app_meta):
+    return {}
+
 @auth(auth_type="file")
 def _file_auth(app_meta):
     conf_auth = app_meta(('config', 'auth'))
@@ -29,10 +33,7 @@ def _file_auth(app_meta):
     file_path = os.path.join(app_meta(['here']), conf_auth.get('src', None))
     users = {}
     if not os.path.isfile(file_path):
-        LOGGER.warning("Auth file '%s' was doesn`t exist,"
-                       "no user will be added",
-                       file_path)
-        return users
+        raise IOError("Auth file '{}' was doesn`t exist".format(file_path))
     config.read(file_path)
     if config.sections():
         LOGGER.warning("Auth file '%s' was empty, no user will be added",

--- a/src/openprocurement/api/auth.py
+++ b/src/openprocurement/api/auth.py
@@ -49,9 +49,6 @@ def _file_auth(app_meta):
             single_key = value.split(',', 1)[0]
             user = {single_key: single_value}
             users.update(user)
-            LOGGER.debug("Authenticate permission for the user %s"
-                         "has been added",
-                         single_key)
         LOGGER.info("Authentication permissions for users from the section "
                     "[%s] has been added",
                     item)

--- a/src/openprocurement/api/auth.py
+++ b/src/openprocurement/api/auth.py
@@ -1,13 +1,18 @@
 # -*- coding: utf-8 -*-
-import os
-import binascii
-from hashlib import sha512
 
-from pyramid.authentication import BasicAuthAuthenticationPolicy, b64decode
 from ConfigParser import ConfigParser
-
+from collections import defaultdict
+from copy import deepcopy
+from hashlib import sha512
+from logging import getLogger
+from pyramid.authentication import BasicAuthAuthenticationPolicy, b64decode
+import binascii
+import os
 
 auth_mapping = {}
+
+
+LOGGER = getLogger("{}.init".format(__name__))
 
 
 def auth(auth_type=None):
@@ -22,9 +27,16 @@ def _file_auth(app_meta):
     conf_auth = app_meta(('config', 'auth'))
     config = ConfigParser()
     file_path = os.path.join(app_meta(['here']), conf_auth.get('src', None))
-    config.read(file_path)
     users = {}
+    if not os.path.isfile(file_path):
+        LOGGER.warning("Auth file '%s' was doesn`t exist, no user will be added",
+                       file_path)
+        return users
 
+    config.read(file_path)
+    if not len(config.sections()):
+        LOGGER.warning("Auth file '%s' was empty, no user will be added",
+                       file_path)
     for item in config.sections():
         for key, value in config.items(item):
             single_value = {
@@ -35,6 +47,10 @@ def _file_auth(app_meta):
             single_key = value.split(',', 1)[0]
             user = {single_key: single_value}
             users.update(user)
+            LOGGER.debug("Authenticate permission for the user %s has been added",
+                         single_key)
+        LOGGER.info("Authentication permissions for users from the section [%s] has been added",
+                    item)
     return users
 
 
@@ -43,10 +59,52 @@ def _auth_factory(auth_type):
     return auth_func
 
 
+def validate_auth_config(users):
+    """
+    Validate configuration what return auth function
+    and return only validated users
+
+    validation check if users have required keys 'group, name, level'
+    and check value of this  keys, expecting that they are not empty
+
+    :param users: result of auth function
+    :type users: abc.Mapping
+
+    :rparam: validated_users
+    :rtype: abc.Mapping
+    """
+
+    validated_users = {}
+    need_keys = ('group', 'name', 'level')
+    for general_key, general_value in users.items():
+        if all((x in general_value.keys() for x in need_keys)) \
+           and all(value for value in general_value.values()):
+            validated_users[general_key] = deepcopy(general_value)
+        else:
+            LOGGER.warning("The user with username '%s' wasn`t added to "
+                           "authentication permission, because invalid config",
+                           general_key)
+    return validated_users
+
+
 def get_auth(app_meta):
+    """
+    Find auth function, get auth users and return only validated users
+
+
+    :param app_meta: function what get app meta configuration
+
+    :rparam: validated_users
+    :rtype: abc.Mapping
+
+    """
     auth_type = app_meta(('config', 'auth', 'type'), None)
     auth_func = _auth_factory(auth_type)
-    return auth_func(app_meta)
+    if hasattr(auth_func, '__call__'):
+        return validate_auth_config(auth_func(app_meta))
+    LOGGER.warning("The authentication configuration has not been added to "
+                   "the app meta settings file")
+    return {}
 
 
 class AuthenticationPolicy(BasicAuthAuthenticationPolicy):
@@ -54,7 +112,7 @@ class AuthenticationPolicy(BasicAuthAuthenticationPolicy):
     def __init__(self, users, realm='OpenProcurement', debug=False):
         self.realm = realm
         self.debug = debug
-        self.users = users
+        self.users = users if users else defaultdict(lambda x: None)
 
     def unauthenticated_userid(self, request):
         """ The userid parsed from the ``Authorization`` request header."""

--- a/src/openprocurement/api/tests/auth.py
+++ b/src/openprocurement/api/tests/auth.py
@@ -5,16 +5,19 @@ from openprocurement.api.auth import AuthenticationPolicy
 from pyramid.tests.test_authentication import TestBasicAuthAuthenticationPolicy
 import mock
 
+
+@mock.patch('openprocurement.api.auth.get_auth')
+def get_mock_auth(return_value, mock_get_auth):
+    mock_get_auth.return_value = return_value
+    return mock_get_auth
+
+
 class AuthTest(TestBasicAuthAuthenticationPolicy):
 
-    @mock.patch('openprocurement.api.auth.get_auth')
-    def get_mock_auth(self, return_value, mock_get_auth):
-        mock_get_auth.return_value = return_value
-        return mock_get_auth
-
     def _makeOne(self, check):
-        user = {'chrisr': {'group': 'tests', 'name':'chrisr', 'level': '1234'}}
-        return AuthenticationPolicy(self.get_mock_auth(user)(), 'SomeRealm')
+        user = {'chrisr': {'group': 'tests', 'name': 'chrisr', 'level': '1234'}}
+        get_auth = get_mock_auth(user)
+        return AuthenticationPolicy(get_auth(), 'SomeRealm')
 
     test_authenticated_userid_utf8 = None
     test_authenticated_userid_latin1 = None


### PR DESCRIPTION
коротке рев'ю:
- в auth.py
. додав логер, який називається так само як файл
.логую перевірку чи існує файл
.логую чи файл пустий
.логую завантаження групи користувачів
.validate_auth_config функція яка валідую отриманий словник користувачів, валідує перевіркою чи є потрібні секції і чи вони не пусті
.якщо в policy прийшов пустий словник користувачів, він запише собі пустий словник
З вище сказаного випливає, якщо в нас не буде в конфіг файлі секції з автентифікацією або буде вказано не існуючий файл або файл буде пустий, все буде далі працювати, і як тільки перший тест якому треба автентифікацію не зможе це зробити отримаємо 
openprocurement.api: INFO: Error on processing request "[                                                
    {                                                                                                    
        "location": "url",                                                                               
        "name": "permission",                                                                            
        "description": "Forbidden"                                                                       
    }                                                                                                    
]"   і далі по логах можна зрозуміти проблему
.test/auth
.створив мок конфігурації і створюю policy з ним

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.api/318)
<!-- Reviewable:end -->
