### PR TITLE
Add logger for an auction's aliases

### DIFF
--- a/src/openprocurement/api/app.py
+++ b/src/openprocurement/api/app.py
@@ -26,8 +26,12 @@ from openprocurement.api.utils import (
     couchdb_json_decode,
     route_prefix,
     json_body,
-    read_yaml
+    read_yaml,
+    get_auctions_aliases,
+    format_auction_aliases,
+    make_logger_info,
 )
+
 from openprocurement.api.database import set_api_security
 from openprocurement.api.design import sync_design
 from openprocurement.api.auth import AuthenticationPolicy, authenticated_role, check_accreditation
@@ -175,9 +179,19 @@ def get_evenly_plugins(config, plugin_map, group):
 
 def _init_plugins(config):
     plugins = config.registry.app_meta(['plugins'])
-    LOGGER.info("Start plugins loading", extra={'MESSAGE_ID': 'included_plugin'})
+    auction_aliases = get_auctions_aliases(plugins)
+
+    # Loading plugins info
+    make_logger_info("START PLUGINS LOADING", {'MESSAGE_ID': 'included_plugin'})
     get_evenly_plugins(config, plugins, 'openprocurement.api.plugins')
-    LOGGER.info("End plugins loading", extra={'MESSAGE_ID': 'included_plugin'})
+    make_logger_info("END PLUGINS LOADING", {'MESSAGE_ID': 'included_plugin'})
+
+    # Auction aliases info
+    make_logger_info("START AUCTION'S ALIASES INFO", {'MESSAGE_ID': 'auctions_aliases'})
+    formatted_aliases = format_auction_aliases(auction_aliases)
+    for alias in formatted_aliases:
+        LOGGER.info(alias)
+    make_logger_info("END AUCTIONS'S ALIASES INFO", {'MESSAGE_ID': 'auctions_aliases'})
 
 
 def main(global_config, **settings):

--- a/src/openprocurement/api/app.py
+++ b/src/openprocurement/api/app.py
@@ -148,7 +148,6 @@ def _set_up_configurator(config, plugins):
 
 
 def _init_plugins(config):
-    plugins = config.registry.app_meta(['plugins'])
     plugins = config.registry.app_meta.plugins
     LOGGER.info("Start plugins loading", extra={'MESSAGE_ID': 'included_plugin'})
     _set_up_configurator(config, plugins)

--- a/src/openprocurement/api/app.py
+++ b/src/openprocurement/api/app.py
@@ -187,11 +187,11 @@ def _init_plugins(config):
     make_logger_info("END PLUGINS LOADING", {'MESSAGE_ID': 'included_plugin'})
 
     # Auction aliases info
-    make_logger_info("START AUCTION'S ALIASES INFO", {'MESSAGE_ID': 'auctions_aliases'})
+    make_logger_info("START ALIASES INFO", {'MESSAGE_ID': 'aliases'})
     formatted_aliases = format_auction_aliases(auction_aliases)
     for alias in formatted_aliases:
         LOGGER.info(alias)
-    make_logger_info("END AUCTIONS'S ALIASES INFO", {'MESSAGE_ID': 'auctions_aliases'})
+    make_logger_info("END ALIASES INFO", {'MESSAGE_ID': 'aliases'})
 
 
 def main(global_config, **settings):

--- a/src/openprocurement/api/app.py
+++ b/src/openprocurement/api/app.py
@@ -152,6 +152,7 @@ def _init_plugins(config):
     LOGGER.info("Start plugins loading", extra={'MESSAGE_ID': 'included_plugin'})
     _set_up_configurator(config, plugins)
     get_evenly_plugins(config, plugins, 'openprocurement.api.plugins')
+    LOGGER.info("End plugins loading", extra={'MESSAGE_ID': 'included_plugin'})
 
 
 def main(global_config, **settings):

--- a/src/openprocurement/api/app.py
+++ b/src/openprocurement/api/app.py
@@ -35,7 +35,6 @@ from openprocurement.api.design import sync_design
 from openprocurement.api.auth import AuthenticationPolicy, authenticated_role, check_accreditation
 
 from openprocurement.api.auth import get_auth
-from openprocurement.auctions.core.utils import get_auctions_aliases, format_auction_aliases
 
 LOGGER = getLogger("{}.init".format(__name__))
 APP_META_FILE = 'app_meta.yaml'
@@ -178,19 +177,11 @@ def get_evenly_plugins(config, plugin_map, group):
 
 def _init_plugins(config):
     plugins = config.registry.app_meta(['plugins'])
-    auction_aliases = get_auctions_aliases(plugins)
 
     # Loading plugins info
     make_logger_info("START PLUGINS LOADING", {'MESSAGE_ID': 'included_plugin'})
     get_evenly_plugins(config, plugins, 'openprocurement.api.plugins')
     make_logger_info("END PLUGINS LOADING", {'MESSAGE_ID': 'included_plugin'})
-
-    # Auction aliases info
-    LOGGER.info('Aliases info')
-    formatted_aliases = format_auction_aliases(auction_aliases)
-    for alias in formatted_aliases:
-        LOGGER.info(alias)
-    LOGGER.info('End aliases info')
 
 
 def main(global_config, **settings):

--- a/src/openprocurement/api/app.py
+++ b/src/openprocurement/api/app.py
@@ -27,8 +27,6 @@ from openprocurement.api.utils import (
     route_prefix,
     json_body,
     read_yaml,
-    get_auctions_aliases,
-    format_auction_aliases,
     make_logger_info,
 )
 
@@ -37,6 +35,7 @@ from openprocurement.api.design import sync_design
 from openprocurement.api.auth import AuthenticationPolicy, authenticated_role, check_accreditation
 
 from openprocurement.api.auth import get_auth
+from openprocurement.auctions.core.utils import get_auctions_aliases, format_auction_aliases
 
 LOGGER = getLogger("{}.init".format(__name__))
 APP_META_FILE = 'app_meta.yaml'
@@ -187,11 +186,11 @@ def _init_plugins(config):
     make_logger_info("END PLUGINS LOADING", {'MESSAGE_ID': 'included_plugin'})
 
     # Auction aliases info
-    make_logger_info("START ALIASES INFO", {'MESSAGE_ID': 'aliases'})
+    LOGGER.info('Aliases info')
     formatted_aliases = format_auction_aliases(auction_aliases)
     for alias in formatted_aliases:
         LOGGER.info(alias)
-    make_logger_info("END ALIASES INFO", {'MESSAGE_ID': 'aliases'})
+    LOGGER.info('End aliases info')
 
 
 def main(global_config, **settings):

--- a/src/openprocurement/api/app.py
+++ b/src/openprocurement/api/app.py
@@ -154,6 +154,7 @@ def _init_plugins(config):
     _set_up_configurator(config, plugins)
     get_evenly_plugins(config, plugins, 'openprocurement.api.plugins')
 
+
 def main(global_config, **settings):
     config = _config_init(global_config, settings)
     _couchdb_connection(config)

--- a/src/openprocurement/api/tests/utils.py
+++ b/src/openprocurement/api/tests/utils.py
@@ -35,18 +35,16 @@ class UtilsTest(unittest.TestCase):
 
     # Mock data for aliases helper functions.
     ALIASES_MOCK_DATA = {
-            'plugins': {
-                'auctions.rubble.financial': {'use_default': True, 'migration': False, 'aliases': ['Alias']},
-            }
-        }
+        'auctions.rubble.financial': {'use_default': True, 'migration': False, 'aliases': ['Alias']}
+    }
 
     def test_get_plugin_aliases(self):
         result = get_plugin_aliases(self.ALIASES_MOCK_DATA)
         self.assertEqual(result, ["auctions.rubble.financial aliases: ['Alias']"])
 
     def test_format_aliases(self):
-        result = format_aliases({'auctions.rubble.financial': []})
-        self.assertEqual(result, ['auctions.rubble.financial aliases: []'])
+        result = format_aliases([{'auctions.rubble.financial': ['Alias']}])
+        self.assertEqual(result, ["auctions.rubble.financial aliases: ['Alias']"])
 
     def test_generate_id(self):
         id = generate_id()

--- a/src/openprocurement/api/tests/utils.py
+++ b/src/openprocurement/api/tests/utils.py
@@ -26,10 +26,27 @@ from openprocurement.api.utils import (
     update_logging_context,
     calculate_business_date,
     get_now,
+    get_plugin_aliases,
+    format_aliases
 )
 
 
 class UtilsTest(unittest.TestCase):
+
+    # Mock data for aliases helper functions.
+    ALIASES_MOCK_DATA = {
+            'plugins': {
+                'auctions.rubble.financial': {'use_default': True, 'migration': False, 'aliases': ['Alias']},
+            }
+        }
+
+    def test_get_plugin_aliases(self):
+        result = get_plugin_aliases(self.ALIASES_MOCK_DATA)
+        self.assertEqual(result, ["auctions.rubble.financial aliases: ['Alias']"])
+
+    def test_format_aliases(self):
+        result = format_aliases({'auctions.rubble.financial': []})
+        self.assertEqual(result, ['auctions.rubble.financial aliases: []'])
 
     def test_generate_id(self):
         id = generate_id()

--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -911,46 +911,6 @@ def read_yaml(name):
     return safe_load(data)
 
 
-def get_auctions_aliases(plugins):
-    """Make an array with an auction's plugins and their aliases
-
-    Output example::
-        [{'auctions.rubble.other': ['dgfOtherAssets', 'exampleRubbleOther']]
-
-    :param plugins An app_meta.yaml file
-    :return: An array with dictionaries objects
-    """
-    aliases = []
-    key = 'auctions.core'
-    auction_plugins = plugins[key]['plugins']
-
-    if key not in plugins.keys() or auction_plugins is None:
-        aliases.append({'Plugins': 'Not included'})
-        return aliases
-
-    for plugin_key in auction_plugins:
-        alias = {plugin_key: auction_plugins[plugin_key]['aliases']}
-        aliases.append(alias)
-    return aliases
-
-
-def format_auction_aliases(aliases):
-    """Converts an auction's aliases into a readable strings.
-
-    Output example::
-        auctions.rubble.other has an next aliases: ['dgfOtherAssets', 'exampleRubbleOther']
-
-    :param aliases: An array with auction's aliases
-    :return: An array with strings
-    """
-    aliases_info = []
-    for obj in aliases:
-        for package_key in obj.keys():
-            message = "{} aliases: {}".format(package_key, obj[package_key])
-            aliases_info.append(message)
-    return aliases_info
-
-
 def make_logger_info(message, extra):
     """Creates a more readable header of a logger information messages.
     :param message: A message

--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -910,16 +910,6 @@ def read_yaml(name):
         data = _file.read()
     return safe_load(data)
 
-def make_logger_info(message, extra):
-    """Creates a more readable header of a logger information messages.
-    :param message: A message
-    :param extra: An extra arguments
-    :return: Logger information message
-    """
-    LOGGER.info('-' * 40)
-    LOGGER.info(message, extra=extra)
-    LOGGER.info('-' * 40)
-
 
 def format_aliases(aliases):
     """Converts an dictionary keys/values in a string representation of an aliases
@@ -957,7 +947,8 @@ def get_plugin_aliases(plugin):
     aliases = {plugin_key: plugin['aliases'] for plugin_key, plugin in plugins.items()}
     formatted_aliases = format_aliases(aliases)
     return formatted_aliases
- 
+
+
 def get_access_token_from_request(request):
     token = request.params.get('acc_token') or request.headers.get('X-Access-Token')
     if not token:

--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -920,3 +920,41 @@ def make_logger_info(message, extra):
     LOGGER.info('-' * 40)
     LOGGER.info(message, extra=extra)
     LOGGER.info('-' * 40)
+
+
+def format_aliases(aliases):
+    """Converts an dictionary keys/values in a string representation of an aliases
+
+    >>> plugin = {'auctions.rubble.financial': []}
+    >>> format_aliases(plugin)
+    ['plugin auctions.rubble.financial aliases []']
+
+    :param aliases: An dictionary object
+    :return: An array with strings
+    """
+    aliases_info = []
+    for plugin_name, alias in aliases.items():
+        msg = '{} aliases: {}'.format(plugin_name, alias)
+        aliases_info.append(msg)
+    return aliases_info
+
+
+def get_plugin_aliases(plugin):
+    """Returns an array with plugin aliases information
+
+    >>> plugin = {'plugins': {'auctions.rubble.financial': {'use_default': True, 'aliases': []}}}
+    >>> get_plugin_aliases(plugin)
+    ['plugin auctions.rubble.financial aliases: []']
+
+    :param plugin A plugin his information
+    :return: An array with aliases in string representation
+    """
+    aliases = []
+    if 'plugins' not in plugin:
+        aliases.append({'Aliases': 'Not included'})
+        return aliases
+    plugins = plugin['plugins']
+
+    aliases = {plugin_key: plugin['aliases'] for plugin_key, plugin in plugins.items()}
+    formatted_aliases = format_aliases(aliases)
+    return formatted_aliases

--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -932,7 +932,7 @@ def format_aliases(aliases):
 def get_plugin_aliases(plugin):
     """Returns an array with plugin aliases information
 
-    >>> plugin = {{'auctions.rubble.financial': {'use_default': True, 'aliases': []}}
+    >>> plugin = {{'auctions.rubble.financial': {'aliases': []}}
     >>> get_plugin_aliases(plugin)
     ['plugin auctions.rubble.financial aliases: []']
 

--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -922,16 +922,17 @@ def format_aliases(aliases):
     :return: An array with strings
     """
     aliases_info = []
-    for plugin_name, alias in aliases.items():
-        msg = '{} aliases: {}'.format(plugin_name, alias)
-        aliases_info.append(msg)
+    for alias in aliases:
+        for k, v in alias.items():
+            info = '{} aliases: {}'.format(k, v)
+            aliases_info.append(info)
     return aliases_info
 
 
 def get_plugin_aliases(plugin):
     """Returns an array with plugin aliases information
 
-    >>> plugin = {'plugins': {'auctions.rubble.financial': {'use_default': True, 'aliases': []}}}
+    >>> plugin = {{'auctions.rubble.financial': {'use_default': True, 'aliases': []}}
     >>> get_plugin_aliases(plugin)
     ['plugin auctions.rubble.financial aliases: []']
 
@@ -939,12 +940,11 @@ def get_plugin_aliases(plugin):
     :return: An array with aliases in string representation
     """
     aliases = []
-    if 'plugins' not in plugin:
-        aliases.append({'Aliases': 'Not included'})
-        return aliases
-    plugins = plugin['plugins']
-
-    aliases = {plugin_key: plugin['aliases'] for plugin_key, plugin in plugins.items()}
+    for key, val in plugin.items():
+        if plugin[key] is None:
+            continue
+        alias = {key: val['aliases']}
+        aliases.append(alias)
     formatted_aliases = format_aliases(aliases)
     return formatted_aliases
 

--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -929,7 +929,7 @@ def get_plugin_aliases(plugin):
 
     >>> data = {'auctions.rubble.financial': {'aliases': []}}
     >>> get_plugin_aliases(data)
-    ['plugin auctions.rubble.financial aliases: []']
+    ['auctions.rubble.financial aliases: []']
 
     :param plugin A plugin his information
     :return: An array with aliases in string representation

--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -909,3 +909,54 @@ def read_yaml(name):
     with open(file_path) as _file:
         data = _file.read()
     return safe_load(data)
+
+
+def get_auctions_aliases(plugins):
+    """Make an array with an auction's plugins and their aliases
+
+    Output example::
+        [{'auctions.rubble.other': ['dgfOtherAssets', 'exampleRubbleOther']]
+
+    :param plugins An app_meta.yaml file
+    :return: An array with dictionaries objects
+    """
+    aliases = []
+    key = 'auctions.core'
+    auction_plugins = plugins[key]['plugins']
+
+    if key not in plugins.keys() or auction_plugins is None:
+        aliases.append({'Plugins': 'Not included'})
+        return aliases
+
+    for plugin_key in auction_plugins:
+        alias = {plugin_key: auction_plugins[plugin_key]['aliases']}
+        aliases.append(alias)
+    return aliases
+
+
+def format_auction_aliases(aliases):
+    """Converts an auction's aliases into a readable strings.
+
+    Output example::
+        auctions.rubble.other has an next aliases: ['dgfOtherAssets', 'exampleRubbleOther']
+
+    :param aliases: An array with auction's aliases
+    :return: An array with strings
+    """
+    aliases_info = []
+    for obj in aliases:
+        for package_key in obj.keys():
+            message = "{} has an next aliases: {}".format(package_key, obj[package_key])
+            aliases_info.append(message)
+    return aliases_info
+
+
+def make_logger_info(message, extra):
+    """Creates a more readable header of a logger information messages.
+    :param message: A message
+    :param extra: An extra arguments
+    :return: Logger information message
+    """
+    LOGGER.info('-' * 40)
+    LOGGER.info(message, extra=extra)
+    LOGGER.info('-' * 40)

--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -913,11 +913,6 @@ def read_yaml(name):
 
 def format_aliases(aliases):
     """Converts an dictionary keys/values in a string representation of an aliases
-
-    >>> plugin = {'auctions.rubble.financial': []}
-    >>> format_aliases(plugin)
-    ['plugin auctions.rubble.financial aliases []']
-
     :param aliases: An dictionary object
     :return: An array with strings
     """
@@ -932,8 +927,8 @@ def format_aliases(aliases):
 def get_plugin_aliases(plugin):
     """Returns an array with plugin aliases information
 
-    >>> plugin = {{'auctions.rubble.financial': {'aliases': []}}
-    >>> get_plugin_aliases(plugin)
+    >>> data = {'auctions.rubble.financial': {'aliases': []}}
+    >>> get_plugin_aliases(data)
     ['plugin auctions.rubble.financial aliases: []']
 
     :param plugin A plugin his information

--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -946,7 +946,7 @@ def format_auction_aliases(aliases):
     aliases_info = []
     for obj in aliases:
         for package_key in obj.keys():
-            message = "{} has an next aliases: {}".format(package_key, obj[package_key])
+            message = "{} aliases: {}".format(package_key, obj[package_key])
             aliases_info.append(message)
     return aliases_info
 


### PR DESCRIPTION
- [x] Add logger output for an auctions plugins aliases
- [x] Make a more readable format for the logger information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.api/320)
<!-- Reviewable:end -->
