### PR TITLE
Fix make_aliases_function

### DIFF
--- a/src/openprocurement/api/tests/utils.py
+++ b/src/openprocurement/api/tests/utils.py
@@ -54,6 +54,10 @@ class UtilsTest(unittest.TestCase):
         result = make_aliases(data)
         self.assertEqual(result, [{'auctions.rubble.financial': ['One', 'Two']}])
 
+    def test_make_bad_alias(self):
+        result = make_aliases(None)
+        self.assertEqual(result, [])
+
     def test_generate_id(self):
         id = generate_id()
 

--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -1050,14 +1050,19 @@ def make_aliases(plugin):
     Returns:
         aliases A list with dictionary objects, where key
     is a name of a plugin, and value is a list of an aliases
+    Otherwise an empty list
     """
-    aliases = []
-    for key, val in plugin.items():
-        if plugin[key] is None:
-            continue
-        alias = {key: val['aliases']}
-        aliases.append(alias)
-    return aliases
+    if plugin:
+        aliases = []
+        for key, val in plugin.items():
+            if plugin[key] is None:
+                continue
+            alias = {key: val['aliases']}
+            aliases.append(alias)
+        return aliases
+    else:
+        LOGGER.warning('Aliases not provided, check your app_meta file')
+        return []
 
 
 def get_plugin_aliases(plugin):


### PR DESCRIPTION
Before if a `plugin` key is None, an application always crashes, but now we just shows a `Logger.warning` message.