### PR TITLE
A701212988669838 transfer token from request

### DIFF
--- a/src/openprocurement/api/models/common.py
+++ b/src/openprocurement/api/models/common.py
@@ -7,7 +7,7 @@ from schematics.types.compound import DictType, ListType, ModelType
 from schematics.types.serializable import serializable
 
 from openprocurement.api.models.roles import organization_roles, auctionParameters_roles
-from openprocurement.api.models.schematics_extender import Model, IsoDateTimeType
+from openprocurement.api.models.schematics_extender import Model, IsoDateTimeType, SHA512Type
 from openprocurement.api.utils import get_now
 
 
@@ -26,7 +26,7 @@ class Revision(Model):
 class BaseResourceItem(SchematicsDocument, Model):
     owner = StringType()  # the broker
     owner_token = StringType()  # token for broker access
-    transfer_token = StringType()  # token wich allows you to change the broker
+    transfer_token = SHA512Type()  # token wich allows you to change the broker
     mode = StringType(choices=['test'])  # need for switching auction to different states
     dateModified = IsoDateTimeType()
     _attachments = DictType(DictType(BaseType), default=dict())  # couchdb attachments

--- a/src/openprocurement/api/models/schematics_extender.py
+++ b/src/openprocurement/api/models/schematics_extender.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import re
 from datetime import datetime, timedelta
 from iso8601 import parse_date, ParseError
 from isodate.duration import Duration
@@ -223,6 +224,20 @@ class HashType(StringType):
         except ValueError:
             raise ConversionError(self.messages['hash_hex'])
         return value
+
+
+class SHA512Type(StringType):
+
+    def __init__(self, regex=r'^[abcdef0123456789]{128}$', **kwargs):
+        super(SHA512Type, self).__init__(regex, **kwargs)
+
+    MESSAGES = {
+        'regex': 'Value is not SHA-512 hash'
+    }
+
+    def validate(self, value):
+        if self.regex is not None and re.match(self.regex, value.lower()) is None:
+            raise ValidationError(self.messages['regex'])
 
 
 class Model(SchematicsModel):

--- a/src/openprocurement/api/tests/utils.py
+++ b/src/openprocurement/api/tests/utils.py
@@ -322,7 +322,7 @@ class UtilsTest(unittest.TestCase):
         request = mock.MagicMock()
         mock_generate_id.return_value = '1234567890abcdef1234567890abcdef'
         request.authenticated_userid = 'concierge'
-        request.headers = {'X-Transfer-Token': 'test_transfer_token'}
+        request.json_body = {'data': {'transfer_token': 'test_transfer_token'}}
 
         item = self.OwnershipTestItem()
         expected_result = {'token': '1234567890abcdef1234567890abcdef'}

--- a/src/openprocurement/api/tests/utils.py
+++ b/src/openprocurement/api/tests/utils.py
@@ -38,6 +38,15 @@ from openprocurement.api.exceptions import ConfigAliasError
 
 class UtilsTest(unittest.TestCase):
 
+    class OwnershipTestItem(object):
+        transfer_token = StringType()
+
+        def __init__(self, owner=None):
+            self.owner = owner
+
+        def get(self, _):
+            return self.owner
+
     # Mock data for aliases helper functions.
     ALIASES_MOCK_DATA = {
         'auctions.rubble.financial': {'use_default': True, 'migration': False, 'aliases': ['Alias']}
@@ -300,19 +309,7 @@ class UtilsTest(unittest.TestCase):
         mock_generate_id.return_value = '1234567890abcdef1234567890abcdef'
         # '0f20c55ac78f7336576260487b865a89a72b396d761ac69d00902cf5bd021d1c51b17191098dc9626f4582ab125efd9053fff1c8b58782e2fe70f7cb4b7bd7ee'
 
-        class Item(object):
-            transfer_token = StringType()
-
-            def __init__(self, owner=None):
-                self.owner = owner
-
-            def get(self, _):
-                if self.owner:
-                    return self.owner
-                else:
-                    return self.owner
-
-        item = Item()
+        item = self.OwnershipTestItem()
         expected_result = {'token': '1234567890abcdef1234567890abcdef', 'transfer': '1234567890abcdef1234567890abcdef'}
 
         result = set_ownership(item, request)
@@ -327,19 +324,7 @@ class UtilsTest(unittest.TestCase):
         request.authenticated_userid = 'concierge'
         request.headers = {'X-Transfer-Token': 'test_transfer_token'}
 
-        class Item(object):
-            transfer_token = StringType()
-
-            def __init__(self, owner=None):
-                self.owner = owner
-
-            def get(self, _):
-                if self.owner:
-                    return self.owner
-                else:
-                    return self.owner
-
-        item = Item()
+        item = self.OwnershipTestItem()
         expected_result = {'token': '1234567890abcdef1234567890abcdef'}
         result = set_ownership(item, request)
         self.assertEqual(result, expected_result)

--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -397,8 +397,9 @@ def get_revision_changes(dst, src):
 
 
 def set_item_transfer_token(item, request, acc):
-    if request.authenticated_userid == 'concierge' and request.headers.get('X-Transfer-Token'):
-        item.transfer_token = request.headers.get('X-Transfer-Token')
+    passed_transfer_token = request.json_body['data'].get('transfer_token')
+    if request.authenticated_userid == 'concierge' and passed_transfer_token:
+        item.transfer_token = passed_transfer_token
     else:
         transfer_token = generate_id()
         item.transfer_token = sha512(transfer_token).hexdigest()

--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -396,6 +396,15 @@ def get_revision_changes(dst, src):
     return make_patch(dst, src).patch
 
 
+def set_item_transfer_token(item, request, acc):
+    if request.authenticated_userid == 'concierge' and request.headers.get('X-Transfer-Token'):
+        item.transfer_token = request.headers.get('X-Transfer-Token')
+    else:
+        transfer_token = generate_id()
+        item.transfer_token = sha512(transfer_token).hexdigest()
+        acc['transfer'] = transfer_token
+
+
 def set_ownership(item, request):
     if not item.get('owner'):
         item.owner = request.authenticated_userid
@@ -403,9 +412,7 @@ def set_ownership(item, request):
     item.owner_token = owner_token  # sha512(owner_token).hexdigest()
     acc = {'token': owner_token}
     if isinstance(getattr(type(item), 'transfer_token', None), StringType):
-        transfer_token = generate_id()
-        item.transfer_token = sha512(transfer_token).hexdigest()
-        acc['transfer'] = transfer_token
+        set_item_transfer_token(item, request, acc)
     return acc
 
 


### PR DESCRIPTION
Рішення передбачає передачу SHA-512 хешу `transfer_token` в кастомному хедері `X-Transfer-Token`.
В подальшому цей спосіб можна змінити або додати інші варіанти передачі токену.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.api/348)
<!-- Reviewable:end -->
