### PR TITLE
Define `__contains__` method for the Period model

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,7 +8,4 @@ exclude =
     bin/,
     eggs/,
     docs/,
-    src/openprocurement/api/tests,
-    src/openprocurement.schemas.dgf,
-    src/schematics-flexible,
-    src/cgi.py
+    src/,

--- a/src/openprocurement/api/models/common.py
+++ b/src/openprocurement/api/models/common.py
@@ -93,6 +93,9 @@ class Period(Model):
         if value and data.get('endDate') and data.get('endDate') < value:
             raise ValidationError(u"period should begin before its end")
 
+    def __contains__(self, date):
+        return (date >= self.startDate) and (date <= self.endDate)
+
 
 class PeriodEndRequired(Period):
     endDate = IsoDateTimeType(required=True)  # The end date for the period.

--- a/src/openprocurement/api/tests/models.py
+++ b/src/openprocurement/api/tests/models.py
@@ -1397,6 +1397,24 @@ class AppSchemaModelsTest(unittest.TestCase):
         self.assertEqual(app_meta.serialize()['here'], os.getcwd())
 
 
+class PeriodModelTest(unittest.TestCase):
+
+    def setUp(self):
+        self.period = Period()
+        self.period.startDate = datetime.now()
+        self.period.endDate = self.period.startDate + timedelta(days=2)
+        self.period.validate()
+
+        self.middle = self.period.startDate + timedelta(days=1)
+        self.out_of_period = self.period.endDate + timedelta(days=1)
+
+    def test_period_contains(self):
+        assert self.middle in self.period
+
+    def test_perion_not_contains(self):
+        assert self.out_of_period not in self.period
+
+
 def suite():
     tests = unittest.TestSuite()
     tests.addTest(unittest.makeSuite(DummyOCDSModelsTest))

--- a/src/openprocurement/api/tests/models.py
+++ b/src/openprocurement/api/tests/models.py
@@ -1411,7 +1411,7 @@ class PeriodModelTest(unittest.TestCase):
     def test_period_contains(self):
         assert self.middle in self.period
 
-    def test_perion_not_contains(self):
+    def test_period_not_contains(self):
         assert self.out_of_period not in self.period
 
 


### PR DESCRIPTION
To make interactions with Period more elegant.
The `__contains__` method of `Period` model was already defined by the `schematics`, but it was unusable for this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.api/374)
<!-- Reviewable:end -->
