### PR TITLE
Update `validate_with` decorator

### DIFF
--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -1236,8 +1236,9 @@ def validate_with(validators):
         @wraps(func)
         def wrapper(*args, **kwargs):
             request = args[1]
+            kw = {'request': request, 'error_handler': error_handler}
             for validator in validators:
-                validator(request)
+                validator(**kw)
             return func(*args, **kwargs)
         return wrapper
     return actual_validator


### PR DESCRIPTION
This change doesn't break any functionality. It's purpose is to prepare
`validate_with` to replace Validate mixin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.api/389)
<!-- Reviewable:end -->
