### PR TITLE
RelatedProcess model

### DIFF
--- a/src/openprocurement/api/constants.py
+++ b/src/openprocurement/api/constants.py
@@ -120,6 +120,12 @@ IDENTIFIER_CODES = ORA_CODES
 ALL_ACCREDITATIONS_GRANTED = '0'
 TEST_ACCREDITATION = 't'
 
+RELATED_PROCESS_TYPE_CHOICES = (
+    'asset',
+    'auction',
+    'lot',
+)
+
 
 class ProjectConfigurator(object):
     """

--- a/src/openprocurement/api/interfaces.py
+++ b/src/openprocurement/api/interfaces.py
@@ -48,3 +48,7 @@ class IProjectConfigurator(Interface):
 
 class IAuction(Interface):
     """ Base auction marker interface """
+
+
+class IResourceManager(Interface):
+    """Base interface for resource's interfaces"""

--- a/src/openprocurement/api/managers.py
+++ b/src/openprocurement/api/managers.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
-from openprocurement.api.utils import error_handler
-
-
 class Manager(object):
     parent_name = ''
     parent = None
@@ -26,11 +23,3 @@ class Manager(object):
 
     def delete(self, request):
         raise NotImplementedError
-
-
-class ValidateMixin(object):
-
-    def _validate(self, request, validators):
-        kwargs = {'request': request, 'error_handler': error_handler}
-        for validator in validators:
-            validator(**kwargs)

--- a/src/openprocurement/api/models/roles.py
+++ b/src/openprocurement/api/models/roles.py
@@ -57,3 +57,18 @@ Administrator_role = whitelist(
     'status',
     'suspended',
 )
+
+related_process_roles = {
+    'view': (schematics_default_role + blacklist()),
+    'create': whitelist(
+        'type',
+        'relatedProcessID',
+        'childID',
+    ),
+    'edit': whitelist(
+        'type',
+        'relatedProcessID',
+        'childID',
+    ),
+    'concierge': whitelist('identifier')
+}

--- a/src/openprocurement/api/plugins/related_processes/__init__.py
+++ b/src/openprocurement/api/plugins/related_processes/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from .utils import add_related_processes_views

--- a/src/openprocurement/api/plugins/related_processes/utils.py
+++ b/src/openprocurement/api/plugins/related_processes/utils.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from cornice import resource
+from openprocurement.api.plugins.related_processes.views.related_processes import (
+    RelatedProcessesResource,
+)
+
+
+def add_related_processes_views(configurator, base_path, factory):
+    """Add related_processes resource basing on some parent resource
+
+        :param configurator: pyramid configurator.
+
+        :param base_path: path for the resource.
+
+        :param factory: factory method from the corresponding traversal module.
+
+    """
+    postfix = '/related_processes/{relatedProcess_id}'
+    collection_postfix = '/related_processes'
+
+    rp_path = base_path + postfix
+    rp_collection_path = base_path + collection_postfix
+
+    rp_res = resource.add_resource(
+        RelatedProcessesResource,
+        collection_path=rp_collection_path,
+        path=rp_path,
+        factory=factory
+    )
+    configurator.add_cornice_resource(rp_res)

--- a/src/openprocurement/api/plugins/related_processes/views/related_processes.py
+++ b/src/openprocurement/api/plugins/related_processes/views/related_processes.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+from openprocurement.api.interfaces import IResourceManager
+from openprocurement.api.utils import (
+    APIResource,
+    json_view,
+    context_unpack,
+)
+from openprocurement.api.validation import (
+    validate_related_process_data,
+    validate_patch_related_process_data,
+)
+
+
+post_validators = (
+    validate_related_process_data,
+)
+patch_validators = (
+    validate_patch_related_process_data,
+)
+
+
+class RelatedProcessesResource(APIResource):
+
+    @json_view(content_type="application/json", permission='create_related_process', validators=post_validators)
+    def collection_post(self):
+        """Create Related Process"""
+        related_process = self.request.validated['relatedProcess']
+        parent = related_process.__parent__
+
+        saved = self.request.registry.getAdapter(
+            parent,
+            IResourceManager,
+        ).related_processes_manager.create(self.request)
+
+        if saved:
+            self.LOGGER.info(
+                'Created related process {}'.format(related_process.id),
+                extra=context_unpack(
+                    self.request, {'MESSAGE_ID': 'related_processes_create'},
+                    {'related_process': related_process.id})
+            )
+            self.request.response.status = 201
+            related_process_route = self.request.matched_route.name.replace("collection_", "")
+            self.request.response.headers['Location'] = self.request.current_route_url(
+                _route_name=related_process_route,
+                relatedProcess_id=related_process.id,
+                _query={}
+            )
+            return {'data': related_process.serialize("view")}
+
+    def collection_get(self):
+        """Related Process List"""
+        collection_data = [i.serialize("view") for i in self.context.relatedProcesses]
+        return {'data': collection_data}
+
+    def get(self):
+        """Related Process Read"""
+        related_process = self.request.context
+        return {'data': related_process.serialize("view")}
+
+    @json_view(content_type="application/json", permission='edit_related_process', validators=patch_validators)
+    def patch(self):
+        """Related Process Update"""
+        related_process = self.request.context
+        parent = related_process.__parent__
+
+        applied = self.request.registry.getAdapter(
+            parent,
+            IResourceManager
+        ).related_processes_manager.update(self.request)
+        if applied:
+            self.LOGGER.info(
+                'Updated relatedProcess {}'.format(related_process.id),
+                extra=context_unpack(self.request, {'MESSAGE_ID': 'related_process_patch'})
+            )
+            return {'data': related_process.serialize("view")}
+
+    @json_view(permission='delete_related_process')
+    def delete(self):
+        """Related Process Delete"""
+        related_process = self.request.context
+        parent = related_process.__parent__
+
+        deleted = self.request.registry.getAdapter(
+            parent,
+            IResourceManager
+        ).related_processes_manager.delete(self.request)
+        if deleted:
+            self.LOGGER.info(
+                'Delete relatedProcess {}'.format(related_process.id),
+                extra=context_unpack(self.request, {'MESSAGE_ID': 'related_process_patch'})
+            )
+            self.request.response.status = 200
+            return {'data': None}

--- a/src/openprocurement/api/tests/blanks/related_processes.py
+++ b/src/openprocurement/api/tests/blanks/related_processes.py
@@ -1,0 +1,254 @@
+# -*- coding: utf-8 -*-
+from copy import deepcopy
+
+
+class RelatedProcessesTestMixinBase(object):
+    """This test mixin assumes that relatedProcesses on every resource behave the same
+
+    The only difference is the URL-prefix, that is located before '/relatedProcesses' in the
+    request path. This mixin requires URL-providing method to adapt to different resources.
+
+    Note, that this mixin must be system-wide applicable, so it will test only basic things,
+    like:
+        - Ability to create the resource
+        - GET the resource
+        - Change the resource
+        - Delete the resource
+
+    Knowing this, all the parent-related functions tesing must be introduced in the child mixin
+    of this one.
+    """
+
+    RESOURCE_POSTFIX = '/related_processes'
+    RESOURCE_ID_POSTFIX = '/related_processes/{0}'
+
+    def mixinSetUp(self):
+        """Local mixin setup, depending on setUp of test case
+
+        What needs to be preparated:
+            Ensure urls to work with:
+                self.base_resource_url ~~ '/auctions/ididid'
+                self.base_resource_collection_url ~~ '/auctions' <-- to test batch mode
+
+            Setup access header:
+                self.access_header ~~ {'X-Access-Token': 'tokenvalue'}
+
+            Setup initial data
+                self.base_resource_initial_data ~~ dict with initial data of base resource
+                self.initial_related_process_data ~~ dict with initial data of related process model
+        """
+        raise NotImplementedError
+
+    def test_related_process_listing(self):
+        self.mixinSetUp()
+
+        response = self.app.get(self.base_resource_url + self.RESOURCE_POSTFIX)
+        self.assertEqual(len(response.json['data']), 0)
+
+        response = self.app.post_json(
+            self.base_resource_url + self.RESOURCE_POSTFIX,
+            params={
+                'data': self.initial_related_process_data
+            },
+            headers=self.access_header
+        )
+        self.assertEqual(response.status, '201 Created')
+        self.assertIn('id', response.json['data'])
+        self.assertEqual(
+            response.json['data']['relatedProcessID'],
+            self.initial_related_process_data['relatedProcessID'])
+        self.assertEqual(response.json['data']['type'], self.initial_related_process_data['type'])
+
+        response = self.app.get(self.base_resource_url + self.RESOURCE_POSTFIX)
+        self.assertEqual(len(response.json['data']), 1)
+
+    def test_create_related_process(self):
+        self.mixinSetUp()
+
+        response = self.app.get(self.base_resource_url + self.RESOURCE_POSTFIX)
+        self.assertEqual(len(response.json['data']), 0)
+
+        data = deepcopy(self.initial_related_process_data)
+        data['identifier'] = 'UA-SOME-VALUE'
+        data['id'] = '1' * 32
+
+        # Create relatedProcess
+        response = self.app.post_json(
+            self.base_resource_url + self.RESOURCE_POSTFIX,
+            params={
+                'data': data
+            },
+            headers=self.access_header
+        )
+        self.assertEqual(response.status, '201 Created')
+        self.assertIn('id', response.json['data'])
+        self.assertNotEqual(response.json['data']['id'], data['id'])
+        self.assertNotIn('identifier', response.json['data'])
+        self.assertEqual(
+            response.json['data']['relatedProcessID'],
+            self.initial_related_process_data['relatedProcessID'])
+        self.assertEqual(response.json['data']['type'], self.initial_related_process_data['type'])
+
+        response = self.app.get(self.base_resource_url + self.RESOURCE_POSTFIX)
+        self.assertEqual(len(response.json['data']), 1)
+
+        response = self.app.get(self.base_resource_url + self.RESOURCE_POSTFIX)
+        self.assertEqual(len(response.json['data']), 1)
+
+    def test_patch_related_process(self):
+        self.mixinSetUp()
+
+        response = self.app.get(self.base_resource_url + self.RESOURCE_POSTFIX)
+        self.assertEqual(len(response.json['data']), 0)
+
+        data = deepcopy(self.initial_related_process_data)
+
+        # Create relatedProcess
+        response = self.app.post_json(
+            self.base_resource_url + self.RESOURCE_POSTFIX,
+            params={
+                'data': data
+            },
+            headers=self.access_header
+        )
+        related_process_id = response.json['data']['id']
+        self.assertEqual(response.status, '201 Created')
+        self.assertIn('id', response.json['data'])
+        self.assertEqual(
+            response.json['data']['relatedProcessID'],
+            self.initial_related_process_data['relatedProcessID']
+        )
+        self.assertEqual(response.json['data']['type'], self.initial_related_process_data['type'])
+
+        childID = 'ch' * 16
+        new_data = {
+            'relatedProcessID': '2' * 32,
+            'childID': childID,
+        }
+
+        # Patch relatedProcess
+        response = self.app.patch_json(
+            self.base_resource_url + self.RESOURCE_ID_POSTFIX.format(related_process_id),
+            params={
+                'data': new_data
+            },
+            headers=self.access_header
+        )
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['id'], related_process_id)
+        self.assertEqual(response.json['data']['relatedProcessID'], new_data['relatedProcessID'])
+        self.assertEqual(response.json['data']['type'], self.initial_related_process_data['type'])
+        self.assertEqual(response.json['data']['childID'], childID)
+
+        response = self.app.get(
+            self.base_resource_url + self.RESOURCE_ID_POSTFIX.format(related_process_id),
+            params={
+                'data': new_data
+            },
+        )
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data']['id'], related_process_id)
+        self.assertEqual(response.json['data']['relatedProcessID'], new_data['relatedProcessID'])
+        self.assertEqual(response.json['data']['type'], self.initial_related_process_data['type'])
+
+    def test_delete_related_process(self):
+        self.mixinSetUp()
+
+        response = self.app.get(self.base_resource_url + self.RESOURCE_POSTFIX)
+        self.assertEqual(len(response.json['data']), 0)
+
+        # Create relatedProcess
+        response = self.app.post_json(
+            self.base_resource_url + self.RESOURCE_POSTFIX,
+            params={
+                'data': self.initial_related_process_data
+            },
+            headers=self.access_header
+        )
+        related_process_id = response.json['data']['id']
+        self.assertEqual(response.status, '201 Created')
+        self.assertIn('id', response.json['data'])
+        self.assertEqual(
+            response.json['data']['relatedProcessID'],
+            self.initial_related_process_data['relatedProcessID']
+        )
+        self.assertEqual(response.json['data']['type'], self.initial_related_process_data['type'])
+
+        response = self.app.get(self.base_resource_url + self.RESOURCE_POSTFIX)
+        self.assertEqual(len(response.json['data']), 1)
+
+        # Delete relatedProcess
+        response = self.app.delete(
+            self.base_resource_url + self.RESOURCE_ID_POSTFIX.format(related_process_id),
+            headers=self.access_header
+        )
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.json['data'], None)
+
+        response = self.app.get(self.base_resource_url + self.RESOURCE_POSTFIX)
+        self.assertEqual(len(response.json['data']), 0)
+
+    def test_patch_with_concierge(self):
+        self.mixinSetUp()
+
+        response = self.app.get(self.base_resource_url + self.RESOURCE_POSTFIX)
+        self.assertEqual(len(response.json['data']), 0)
+
+        # Create relatedProcess
+        response = self.app.post_json(
+            self.base_resource_url + self.RESOURCE_POSTFIX,
+            params={
+                'data': self.initial_related_process_data
+            },
+            headers=self.access_header
+        )
+        self.assertEqual(response.status, '201 Created')
+        self.assertIn('id', response.json['data'])
+        self.assertEqual(
+            response.json['data']['relatedProcessID'],
+            self.initial_related_process_data['relatedProcessID'])
+        self.assertEqual(response.json['data']['type'], self.initial_related_process_data['type'])
+
+    def test_create_related_process_batch_mode(self):
+        self.mixinSetUp()
+
+        data = deepcopy(self.base_resource_initial_data)
+        related_process_1 = {
+            'id': '1' * 32,
+            'identifier': 'SOME-IDENTIFIER',
+            'type': 'asset',
+            'relatedProcessID': '2' * 32
+        }
+        data['relatedProcesses'] = [
+           related_process_1
+        ]
+        response = self.app.post_json(self.base_resource_collection_url, params={'data': data})
+        parent_id = response.json['data']['id']
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(len(response.json['data']['relatedProcesses']), 1)
+        self.assertEqual(response.json['data']['relatedProcesses'][0]['type'], related_process_1['type'])
+        self.assertEqual(
+            response.json['data']['relatedProcesses'][0]['relatedProcessID'],
+            related_process_1['relatedProcessID']
+        )
+        self.assertNotEqual(response.json['data']['relatedProcesses'][0]['id'], related_process_1['id'])
+        self.assertNotIn('identifier', response.json['data']['relatedProcesses'][0])
+
+        related_process_id = response.json['data']['relatedProcesses'][0]['id']
+
+        # Check relatedProcess resource
+        # due to test universality, there's a trying to avoid tight places
+        templates = ('/{0}', '{0}')
+        for t in templates:
+            try:
+                response = self.app.get(
+                    self.base_resource_collection_url +
+                    t.format(parent_id) +
+                    self.RESOURCE_ID_POSTFIX.format(related_process_id)
+                )
+            except Exception:
+                continue
+        self.assertEqual(response.json['data']['type'], related_process_1['type'])
+        self.assertEqual(response.json['data']['relatedProcessID'], related_process_1['relatedProcessID'])
+        self.assertNotEqual(response.json['data']['id'], related_process_1['id'])
+        self.assertNotIn('identifier', response.json['data'])

--- a/src/openprocurement/api/tests/utils.py
+++ b/src/openprocurement/api/tests/utils.py
@@ -32,7 +32,8 @@ from openprocurement.api.utils import (
     get_plugin_aliases,
     format_aliases,
     make_aliases,
-    connection_mock_config
+    connection_mock_config,
+    call_before,
 )
 from openprocurement.api.exceptions import ConfigAliasError
 
@@ -598,10 +599,32 @@ class CalculateBusinessDateTestCase(unittest.TestCase):
         self.assertEqual(result, target_end)
 
 
+class CallBeforeTestCase(unittest.TestCase):
+
+    class SomeClass(object):
+        def __init__(self):
+            self.run_first = False
+
+        def want_run_first(self, *args, **kwargs):
+            self.run_first = True
+
+        @call_before(want_run_first)
+        def some_method(self, param1, param2=None):
+            pass
+
+    def setUp(self):
+        self.scarecrow = self.SomeClass()
+
+    def test_ok(self):
+        self.scarecrow.some_method('some_param', param2='i_am_here')
+        self.assertTrue(self.scarecrow.run_first)
+
+
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(UtilsTest))
     suite.addTest(unittest.makeSuite(CalculateBusinessDateTestCase))
+    suite.addTest(unittest.makeSuite(CallBeforeTestCase))
     return suite
 
 

--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -1250,3 +1250,14 @@ def get_auction(model):
         if model is None:
             return None
     return model
+
+
+def call_before(method):
+    """Calls some method before actual call of decorated method"""
+    def caller(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            method(*args, **kwargs)  # call mehod passed in the param
+            return func(*args, **kwargs)  # call decorated method
+        return wrapper
+    return caller

--- a/src/openprocurement/api/validation.py
+++ b/src/openprocurement/api/validation.py
@@ -314,3 +314,17 @@ def validate_dkpp(items, *args):
         raise ValidationError(
             u"One of additional classifications should be one of [{0}].".format(
                 ', '.join(ADDITIONAL_CLASSIFICATIONS_SCHEMES)))
+
+
+def validate_related_process_data(request, error_handler, **kwargs):
+    update_logging_context(request, {'relatedProcess_id': '__new__'})
+    context = request.context if 'relatedProcesses' in request.context else request.context.__parent__
+    model = type(context).relatedProcesses.model_class
+    validate_data(request, model, "relatedProcess")
+
+
+def validate_patch_related_process_data(request, error_handler, **kwargs):
+    update_logging_context(request, {'relatedProcess_id': '__new__'})
+    context = request.context if 'relatedProcess' in request.context else request.context.__parent__
+    model = type(context).relatedProcesses.model_class
+    validate_data(request, model)


### PR DESCRIPTION
- Update RelatedProcess model
- Add childID and comments.
- Remove ValidateMixin
- call_before decorator
- Roughly port PelatedProcess test mixin
- Remove decorator
- Extract loki-specific test logic
- Sum `ensure` methods into `mixinSetUp`
- Bring relatedProcesses validators
- Exctract loki-specific test logic from the relatedProcesses test mixin
- Update roles of the RelatedProcess model make it whitelist-based.
- Test childID
- BaseMigrationRunner & BaseMigrationStep
- Mechanism for efficient migration description.
- IResourceManager interface
- RelatedProcesses universal view & util to enable it
- RelatedProcess include util
- Update log messages, etc.
- Refine relatedProcess test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.api/390)
<!-- Reviewable:end -->
