### PR TITLE
Migration run_step logic update

### DIFF
--- a/src/openprocurement/api/migration.py
+++ b/src/openprocurement/api/migration.py
@@ -109,6 +109,9 @@ class BaseMigrationsRunner(object):
         for doc_row in input_generator:
             # migrate single document
             migrated_doc = st.migrate_document(doc_row.doc)
+            if migrated_doc is None:
+                LOGGER.info("Skipping document")
+                continue
             migrated_documents.append(migrated_doc)
 
             # bulk write on threshold overgrow


### PR DESCRIPTION
None was added to the migration's output buffer
when migration step has returned None.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.api/398)
<!-- Reviewable:end -->
