### PR TITLE
Rename `childID` of the RelatedProcess model to `parentID`

### DIFF
--- a/src/openprocurement/api/models/roles.py
+++ b/src/openprocurement/api/models/roles.py
@@ -63,13 +63,13 @@ related_process_roles = {
     'create': whitelist(
         'type',
         'relatedProcessID',
-        'childID',
+        'parentID',
         'identifier',
     ),
     'edit': whitelist(
         'type',
         'relatedProcessID',
-        'childID',
+        'parentID',
     ),
     'concierge': whitelist('identifier')
 }

--- a/src/openprocurement/api/models/schema.py
+++ b/src/openprocurement/api/models/schema.py
@@ -584,7 +584,7 @@ class RelatedProcess(Model):
     type = StringType(choices=RELATED_PROCESS_TYPE_CHOICES)
     relatedProcessID = MD5Type(required=True)  # id of the real object, that this model poins on
     identifier = StringType()  # external identifier, i.e. paper-documental ID
-    childID = StringType()
+    parentID = StringType()
 
     class Options:
         roles = related_process_roles

--- a/src/openprocurement/api/tests/blanks/related_processes.py
+++ b/src/openprocurement/api/tests/blanks/related_processes.py
@@ -120,10 +120,10 @@ class RelatedProcessesTestMixinBase(object):
         )
         self.assertEqual(response.json['data']['type'], self.initial_related_process_data['type'])
 
-        childID = 'ch' * 16
+        parentID = 'ch' * 16
         new_data = {
             'relatedProcessID': '2' * 32,
-            'childID': childID,
+            'parentID': parentID,
         }
 
         # Patch relatedProcess
@@ -138,7 +138,7 @@ class RelatedProcessesTestMixinBase(object):
         self.assertEqual(response.json['data']['id'], related_process_id)
         self.assertEqual(response.json['data']['relatedProcessID'], new_data['relatedProcessID'])
         self.assertEqual(response.json['data']['type'], self.initial_related_process_data['type'])
-        self.assertEqual(response.json['data']['childID'], childID)
+        self.assertEqual(response.json['data']['parentID'], parentID)
 
         response = self.app.get(
             self.base_resource_url + self.RESOURCE_ID_POSTFIX.format(related_process_id),


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.api/405)
<!-- Reviewable:end -->
