### PR TITLE
Migration mechanism development

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ entry_points = {
         'transferring = openprocurement.api.plugins.transferring.includeme:includeme'
     ],
     'console_scripts': [
-        'bootstrap_api_security = openprocurement.api.database:bootstrap_api_security'
+        'bootstrap_api_security = openprocurement.api.database:bootstrap_api_security',
+        'migrate = openprocurement.api.utils:run_migrations_console_entrypoint',
     ]
 }
 

--- a/src/openprocurement/api/app.py
+++ b/src/openprocurement/api/app.py
@@ -28,6 +28,7 @@ from openprocurement.api.utils import (
     read_yaml,
     get_evenly_plugins,
     get_plugins,
+    create_app_meta,
 )
 
 from openprocurement.api.database import set_api_security
@@ -36,11 +37,9 @@ from openprocurement.api.auth import AuthenticationPolicy, authenticated_role, c
 from openprocurement.api.configurator import Configurator as ProjectConfigurator, configuration_info
 from openprocurement.api.interfaces import IProjectConfigurator
 from openprocurement.api.auth import get_auth
-from openprocurement.api.config import AppMetaSchema
+from openprocurement.api.constants import APP_META_FILE
 
 LOGGER = getLogger("{}.init".format(__name__))
-APP_META_FILE = 'app_meta.yaml'
-
 
 def _couchdb_connection(config):
     database_config = config.registry.app_meta.config.db
@@ -76,26 +75,9 @@ def _document_service_key(config):
     config.registry.keyring = docsrv_conf.init_keyring(dockey)
 
 
-def _create_app_meta(global_config):
-    """This function returns schematics.models.Model object which contains configuration
-    of the application. Configuration file reading will be performed only once.
-
-    Current function must be called only once during app initialization.
-
-    :param global_config: it is instance of pyramid global config
-    :type global_config: dict
-    :rtype: schematics.models.Model
-    """
-    file_place = os.path.join(global_config['here'], APP_META_FILE)
-    config_data = dd(lambda: None, read_yaml(file_place))
-    config_data['here'] = copy(global_config['here'])
-    app_meta = AppMetaSchema(config_data)
-    app_meta.validate()
-    return app_meta
-
-
 def _config_init(global_config, settings):
-    app_meta = _create_app_meta(global_config)
+    app_meta_filepath = os.path.join(global_config['here'], APP_META_FILE)
+    app_meta = create_app_meta(app_meta_filepath)
     config = Configurator(
         autocommit=True,
         settings=settings,

--- a/src/openprocurement/api/constants.py
+++ b/src/openprocurement/api/constants.py
@@ -24,6 +24,8 @@ SESSION = Session()
 SCHEMA_VERSION = 24
 SCHEMA_DOC = 'openprocurement_schema'
 
+APP_META_FILE = 'app_meta.yaml'
+
 TZ = timezone(os.environ['TZ'] if 'TZ' in os.environ else 'Europe/Kiev')
 SANDBOX_MODE = os.environ.get('SANDBOX_MODE', False)
 AUCTIONS_COMPLAINT_STAND_STILL_TIME = timedelta(days=3)

--- a/src/openprocurement/api/migration.py
+++ b/src/openprocurement/api/migration.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import sys
 import logging
 from openprocurement.api.constants import SCHEMA_VERSION, SCHEMA_DOC
 from openprocurement.api.utils import get_plugins

--- a/src/openprocurement/api/tests/base.py
+++ b/src/openprocurement/api/tests/base.py
@@ -124,7 +124,7 @@ class BaseWebTest(unittest.TestCase):
         if not getattr(cls, 'app', None) or getattr(cls, 'docservice', True):
             with nested(
                 patch(
-                    'openprocurement.api.app.read_yaml',
+                    'openprocurement.api.utils.read_yaml',
                     return_value=deepcopy(cls.mock_config),
                     autospec=True
                 ),

--- a/src/openprocurement/api/tests/fixtures/config.py
+++ b/src/openprocurement/api/tests/fixtures/config.py
@@ -8,28 +8,78 @@ DB_USER = os.environ.get('DB_USER', 'op')
 DB_PASS = os.environ.get('DB_PASS', 'op')
 API_VERSION = os.environ.get('API_VERSION', '2.5')
 PARTIAL_MOCK_CONFIG = {
-    "config":{
-        "db":{
-            "url":"{host}:{port}".format(host=DB_HOST, port=DB_PORT),
-            "db_name":"db_tests_{}".format(uuid.uuid4().hex),
-            "writer":{
-                "password":DB_PASS,
-                "name":DB_USER
+    "config": {
+        "db": {
+            "url": "http://{host}:{port}".format(host=DB_HOST, port=DB_PORT),
+            "db_name": "db_tests_{}".format(uuid.uuid4().hex),
+            "writer": {
+                "password": DB_PASS,
+                "name": DB_USER
             },
-            "type":"couchdb"
+            "type": "couchdb"
         },
-        "auth":{
-            "src":"auth.ini",
-            "type":"file"
+        "auth": {
+            "src": "auth.ini",
+            "type": "file"
         },
-        "main":{
+        "main": {
             "api_version": API_VERSION
         }
     },
-    "plugins":{
-        "api":{
-            "plugins":{
+    "plugins": {
+        "api": {
+            "plugins": {
                 "transferring": None
+            }
+        }
+    }
+}
+
+
+# only for testing
+RANDOM_PLUGINS = {
+    "api": {
+        "plugins": {
+            "transferring": {
+                "plugins": {
+                    "auctions.transferring": None
+                }
+            },
+            "auctions.core": {
+                "plugins": {
+                    "auctions.rubble.financial": {
+                        "use_default": True,
+                        "plugins": {
+                            "rubble.financial.migration": None
+                        },
+                        "migration": False,
+                        "accreditation": {
+                            "edit": [
+                                2
+                            ],
+                            "create": [
+                                1
+                            ]
+                        },
+                        "aliases": []
+                    },
+                    "auctions.rubble.other": {
+                        "use_default": True,
+                        "plugins": {
+                            "rubble.other.migration": None
+                        },
+                        "migration": True,
+                        "accreditation": {
+                            "edit": [
+                                2
+                            ],
+                            "create": [
+                                1
+                            ]
+                        },
+                        "aliases": []
+                    }
+                }
             }
         }
     }

--- a/src/openprocurement/api/tests/utils.py
+++ b/src/openprocurement/api/tests/utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 import mock
 import unittest
 
@@ -6,6 +7,7 @@ from datetime import timedelta, datetime, date, time
 from hashlib import sha512
 from uuid import UUID
 from pytz import timezone
+from copy import deepcopy
 
 from cornice.errors import Errors
 from couchdb.client import Document
@@ -14,30 +16,38 @@ from schematics.types import StringType
 
 from openprocurement.api.utils import (
     apply_data_patch,
+    calculate_business_date,
+    call_before,
+    collect_packages_for_migration,
+    connection_mock_config,
     context_unpack,
+    create_app_meta,
+    decrypt,
+    dump_dict_to_tempfile,
+    encrypt,
     error_handler,
-    decrypt, encrypt,
     forbidden,
+    format_aliases,
     generate_docservice_url,
     generate_id,
     get_content_configurator,
+    get_file_path,
+    get_now,
+    get_plugin_aliases,
     get_revision_changes,
+    make_aliases,
+    path_to_kv,
     prepare_patch,
+    run_migrations_console_entrypoint,
+    search_list_with_dicts,
     set_modetest_titles,
     set_ownership,
     set_parent,
     update_logging_context,
-    calculate_business_date,
-    get_now,
-    get_file_path,
-    get_plugin_aliases,
-    format_aliases,
-    make_aliases,
-    connection_mock_config,
-    call_before,
-    search_list_with_dicts,
 )
 from openprocurement.api.exceptions import ConfigAliasError
+from openprocurement.api.tests.base import MOCK_CONFIG
+from openprocurement.api.tests.fixtures.config import RANDOM_PLUGINS
 
 
 class UtilsTest(unittest.TestCase):
@@ -748,12 +758,113 @@ class TestSearchListWithDicts(unittest.TestCase):
         assert result is None
 
 
+class CreateAppMetaTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_app_meta_path = dump_dict_to_tempfile(MOCK_CONFIG)
+
+    def tearDown(self):
+        os.unlink(self.temp_app_meta_path)
+
+    def test_ok(self):
+        app_meta = create_app_meta(self.temp_app_meta_path)
+        root_keys = ('config', 'plugins', 'here')
+        for k in root_keys:
+            self.assertIn(k, app_meta.keys(), 'AppMeta was created without required base keys')
+
+
+class RunMigrationsConsoleEntrypointTestCase(unittest.TestCase):
+
+    @mock.patch('openprocurement.api.utils.run_migrations')
+    @mock.patch('openprocurement.api.utils.create_app_meta')
+    @mock.patch('openprocurement.api.utils.sys')
+    def test_ok(self, argv_mock, create_app_meta, run_migrations):
+        argv_mock.configure_mock(**{'argv': ('1', '2')})
+        create_app_meta.return_value = 'test_app_meta'
+
+        run_migrations_console_entrypoint()
+        self.assertEqual(
+            run_migrations.call_args[0][0], 'test_app_meta', 'run_migrations did not received proper argument'
+        )
+
+
+class PathToKvTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.testdict = {
+            'forest': {
+                'tree1': {
+                    'leaf1': 'green',
+                    'leaf2': 'brown'
+                },
+                'tree2': {
+                    'leaf1': 'green',
+                    'leaf2': 'brown',
+                    'leaf3': 'green-brown'
+                }
+            }
+        }
+
+    def test_search_single_result(self):
+        kv = ('leaf3', 'green-brown')
+        target_r = (
+            ('forest', 'tree2', 'leaf3'),
+        )
+
+        r = path_to_kv(kv, self.testdict)
+
+        self.assertEqual(r, target_r)
+
+    def test_search_multiple_results(self):
+        kv = ('leaf1', 'green')
+        target_r = (
+            ('forest', 'tree1', 'leaf1'),
+            ('forest', 'tree2', 'leaf1'),
+        )
+
+        r = path_to_kv(kv, self.testdict)
+
+        self.assertEqual(r, target_r)
+
+    def test_no_results(self):
+        kv = ('root', 'no')
+        target_r = None
+
+        r = path_to_kv(kv, self.testdict)
+
+        self.assertEqual(r, target_r)
+
+
+class CollectPackagesForMigrationTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.plugins = deepcopy(RANDOM_PLUGINS)
+
+    def test_ok(self):
+        result = collect_packages_for_migration(self.plugins)
+
+        target_result = ('auctions.rubble.other',)
+        self.assertEqual(result, target_result)
+
+    def test_none_find(self):
+        self.plugins['api']['plugins']['auctions.core']['plugins']['auctions.rubble.other']['migration'] = False
+
+        result = collect_packages_for_migration(self.plugins)
+
+        target_result = None
+        self.assertEqual(result, target_result)
+
+
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(UtilsTest))
     suite.addTest(unittest.makeSuite(CalculateBusinessDateTestCase))
     suite.addTest(unittest.makeSuite(CallBeforeTestCase))
     suite.addTest(unittest.makeSuite(TestSearchListWithDicts))
+    suite.addTest(unittest.makeSuite(CreateAppMetaTestCase))
+    suite.addTest(unittest.makeSuite(RunMigrationsConsoleEntrypointTestCase))
+    suite.addTest(unittest.makeSuite(PathToKvTestCase))
+    suite.addTest(unittest.makeSuite(CollectPackagesForMigrationTestCase))
     return suite
 
 

--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 import os
+import sys
 import decimal
 import simplejson
+import tempfile
+
 from copy import deepcopy
 from base64 import b64encode, b64decode
 from binascii import hexlify, unhexlify
 from copy import copy
+from collections import defaultdict
 from datetime import datetime, timedelta, time, date as date_type
 from email.header import decode_header
 from functools import partial, wraps
@@ -21,6 +25,7 @@ from urlparse import urlparse, urlunsplit, parse_qsl, parse_qs
 from uuid import uuid4
 from pkg_resources import iter_entry_points
 from pytz import utc
+from yaml import safe_load
 
 import collections
 
@@ -58,6 +63,8 @@ from openprocurement.api.interfaces import (
 )
 from openprocurement.api.traversal import factory
 from openprocurement.api.exceptions import ConfigAliasError
+from openprocurement.api.config import AppMetaSchema
+from openprocurement.api.database import set_api_security
 
 
 ACCELERATOR_RE = compile(r'.accelerator=(?P<accelerator>\d+)')
@@ -1102,12 +1109,7 @@ def get_document_creation_date(document):
     return (document.get('revisions')[0].date if document.get('revisions') else get_now())
 
 
-def read_yaml(name):
-    import inspect
-    from yaml import safe_load
-    caller_file = inspect.stack()[1][1]
-    caller_dir = os.path.dirname(os.path.realpath(caller_file))
-    file_path = os.path.join(caller_dir, name)
+def read_yaml(file_path):
     with open(file_path) as _file:
         data = _file.read()
     return safe_load(data)
@@ -1332,10 +1334,125 @@ def log_auction_status_change(request, auction, status):
     LOGGER.info(msg, extra=context_unpack(request, context_msg))
     return True
 
-  
+
 def read_json(filename, file_dir):
     """Read file & deserialize it as JSON"""
     full_filename = os.path.join(file_dir, filename)
     with open(full_filename, 'r') as f:
         data = f.read()
     return loads(data)
+
+
+def create_app_meta(filepath):
+    """This function returns schematics.models.Model object which contains configuration
+    of the application. Configuration file reading will be performed only once.
+
+    Current function must be called only once during app initialization.
+    """
+    config_data = defaultdict(lambda: None, read_yaml(filepath))
+    # set app_meta.here as it's parent directory
+    config_data['here'] = os.path.dirname(filepath)
+    # load & validate app_meta
+    app_meta = AppMetaSchema(config_data)
+    app_meta.validate()
+    return app_meta
+
+
+def dump_dict_to_tempfile(dict_to_dump, fmt='json'):
+    """Writes dict to a temporary file and returns it's path"""
+
+    if fmt == 'json':
+        s = dumps(dict_to_dump)
+
+    tf = tempfile.NamedTemporaryFile('w', delete=False)
+    tf.write(s)
+    tf.close()
+
+    return tf.name
+
+
+def path_to_kv(kv, d):
+    """Traverse nested dict recursively & search for a given k/v
+
+    :param kv: key/value to seek, tuple
+    :param d: dict to search in
+
+    :returns: path(s) to a target k/v
+    """
+    found_paths = []  # buffer for the results
+    current_path = []
+
+    def search(curr_dict, curr_path):
+        for key, value in curr_dict.iteritems():
+            if key == kv[0] and value == kv[1]:
+                curr_path.append(key)
+                found_paths.append(tuple(curr_path))
+            elif isinstance(value, dict):
+                new_path = copy(curr_path)
+                new_path.append(key)
+                search(value, new_path)
+
+    search(d, current_path)
+
+    if len(found_paths) > 0:
+        return tuple(found_paths)
+
+    return None
+
+
+def collect_packages_for_migration(plugins):
+    migration_kv = ('migration', True)
+    results_buffer = []
+
+    paths = path_to_kv(migration_kv, plugins)
+    if not paths:
+        return None
+
+    for path in paths:
+        package_name = path[-2]
+        results_buffer.append(package_name)
+
+    if len(results_buffer) > 0:
+        return tuple(results_buffer)
+
+    return None
+
+
+def collect_migration_entrypoints(package_names, name='main'):
+    """Collect migration functions from specified entrypoint groups"""
+    # form entrypoint groups names
+    ep_group_names = []
+    for g in package_names:
+        ep_group_name = '{0}.migration'.format(g)
+        ep_group_names.append(ep_group_name)
+
+    ep_funcs = []
+    for group in ep_group_names:
+        for ep in iter_entry_points(group, name):
+            ep_func = ep.load()
+            ep_funcs.append(ep_func)
+
+    return ep_funcs
+
+
+def run_migrations(app_meta):
+    packages_for_migrations_names = collect_packages_for_migration(app_meta.plugins)
+    ep_funcs = collect_migration_entrypoints(packages_for_migrations_names)
+    _, _, _, db = set_api_security(app_meta.config.db)
+
+    for migration_func in ep_funcs:
+        migration_func(db)
+
+
+def run_migrations_console_entrypoint():
+    """Search for migrations in the app_meta and run them if enabled
+
+    This is an entrypoint for console script.
+    """
+    # due to indirect calling of this function, namely through the script,
+    # generated from the package's entrypionts, argparse lib usage is troublesome
+    if len(sys.argv) < 2:
+        sys.exit('Provide app_meta location as first argument')
+    am_filepath = sys.argv[1]
+    app_meta = create_app_meta(am_filepath)
+    run_migrations(app_meta)


### PR DESCRIPTION
- Extract `create_app_meta` to the utils to reuse it.
- Migration runner stub
- Add filename arg to `create_app_meta` func
- Stubs for run_migrations & related tests
- Remove unneeded MigrationProcessRunner
- Fix mock path in the tests.base
- Remove obsolete info from the docstring
- Add migrate entrypoint
- app_meta constructing refactor
    - Optimize `read_yaml`
    - Use only app_meta filepath as param for `create_app_meta`
- Comment on argparse usage
- create_app_meta test
- Introduce `dump_dict_to_tempfile`
- Rename entrypoint
- run_migrations -> run_migrations_console_entrypoint
- run_migrations_console_entrypoint + test
- Add missing whitespaces after columns
- path_to_kv util
- collect_packages_for_migration util
- path_to_kv test for no results
- Define scheme for the DB URL
- Migration entrypoints logic