### PR TITLE
calculate_business_date bugfix

### DIFF
--- a/src/openprocurement/api/tests/utils.py
+++ b/src/openprocurement/api/tests/utils.py
@@ -558,9 +558,9 @@ class CalculateBusinessDateTestCase(unittest.TestCase):
         self.assertEqual(result, target_end)
 
     def test_reverse_start_is_not_holiday_specific_hour_not_set(self):
-        start = datetime(2018, 7, 20)
+        start = datetime(2018, 7, 20, 17, 15)
         days_to_substract = timedelta(days=-4)
-        target_end = datetime(2018, 7, 16)
+        target_end = datetime(2018, 7, 16, 17, 15)
 
         result = calculate_business_date(start, days_to_substract, None, working_days=True, specific_hour=None)
 

--- a/src/openprocurement/api/utils.py
+++ b/src/openprocurement/api/utils.py
@@ -1008,7 +1008,7 @@ def validate_jump_length(days_to_jump):
 
 
 def operate_on_last_working_day(time_cursor, start_is_holiday, specific_hour, reverse_calculations):
-    if (start_is_holiday or reverse_calculations) and not specific_hour:
+    if start_is_holiday and not specific_hour:
         time_cursor = round_out_day(time_cursor, reverse_calculations)
     return time_cursor
 


### PR DESCRIPTION
Reverse calculations non neccesarily do day rounding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.api/417)
<!-- Reviewable:end -->
