### PR TITLE
Database state manager

### DIFF
--- a/src/openprocurement/api/constants.py
+++ b/src/openprocurement/api/constants.py
@@ -30,6 +30,8 @@ TZ = timezone(os.environ['TZ'] if 'TZ' in os.environ else 'Europe/Kiev')
 SANDBOX_MODE = os.environ.get('SANDBOX_MODE', False)
 AUCTIONS_COMPLAINT_STAND_STILL_TIME = timedelta(days=3)
 
+DB_STATE_DOC_DEFAULT_NAME = 'db_state'
+
 DOCUMENT_BLACKLISTED_FIELDS = ('title', 'format', 'url', 'dateModified', 'hash')
 DOCUMENT_WHITELISTED_FIELDS = ('id', 'datePublished', 'author', '__parent__')
 

--- a/src/openprocurement/api/database.py
+++ b/src/openprocurement/api/database.py
@@ -98,6 +98,8 @@ def _reader_update(users_db, security_users, config):
 
 
 def set_admin_api_security(server, db_name, config):
+    from openprocurement.api.utils.db_state_doc import DBStateDocManager
+
     aserver = Server(config.create_url('admin'), session=Session(retry_delays=range(10)))
     users_db = aserver['_users']
     _update_security(users_db, "Updating users db security",
@@ -118,11 +120,13 @@ def set_admin_api_security(server, db_name, config):
                     extra={'MESSAGE_ID': 'update_api_validate_doc'})
         adb.save(auth_doc)
     db = server[db_name]
+    DBStateDocManager(db).assure_doc()
     return aserver, server, adb, db
 
 
 def set_api_security(config):
-    # CouchDB connection
+    from openprocurement.api.utils.db_state_doc import DBStateDocManager
+
     db_name = os.environ.get('DB_NAME', config.db_name)
     db_full_url = config.create_url('writer')
     server = Server(db_full_url, session=Session(retry_delays=range(10)))
@@ -139,6 +143,7 @@ def set_api_security(config):
         db = server[db_name]
         aserver = None
         adb = None
+        DBStateDocManager(db).assure_doc()
     return aserver, server, adb, db
 
 

--- a/src/openprocurement/api/models/common.py
+++ b/src/openprocurement/api/models/common.py
@@ -2,7 +2,7 @@
 from couchdb_schematics.document import SchematicsDocument
 
 from schematics.exceptions import ValidationError
-from schematics.types import StringType, BaseType, FloatType, EmailType, URLType, IntType
+from schematics.types import StringType, BaseType, EmailType, URLType, IntType
 from schematics.types.compound import DictType, ListType, ModelType
 from schematics.types.serializable import serializable
 
@@ -157,7 +157,7 @@ class BasicValue(Model):
 
 
 class Classification(Model):
-    _id_field_validators = () # tuple of validators for field 'id'
+    _id_field_validators = ()  # tuple of validators for field 'id'
     scheme = StringType(required=True)  # The classification scheme for the goods
     id = StringType(required=True)  # The classification ID from the Scheme used
     description = StringType(required=True)  # A description of the goods, services to be provided.
@@ -206,3 +206,14 @@ class RegistrationDetails(Model):
     def validate_registrationDate(self, data, value):
         if value and data['status'] != 'complete':
             raise ValidationError(u"You can fill registrationDate only when status is complete")
+
+
+class MigrationInfo(SchematicsDocument):
+    name = StringType(required=True)
+    description = StringType()
+    applied = IsoDateTimeType(required=True)
+
+
+class DBState(SchematicsDocument):
+    db_created = IsoDateTimeType(required=True)
+    migrations = ListType(ModelType(MigrationInfo), default=list())

--- a/src/openprocurement/api/models/schematics_extender.py
+++ b/src/openprocurement/api/models/schematics_extender.py
@@ -18,7 +18,7 @@ from schematics.types import (
 )
 from schematics.transforms import blacklist, export_loop, convert
 from openprocurement.api.constants import TZ
-from openprocurement.api.utils import set_parent
+from openprocurement.api.utils.common import set_parent
 
 
 class DecimalType(BaseDecimalType):

--- a/src/openprocurement/api/tests/db_state_doc_test.py
+++ b/src/openprocurement/api/tests/db_state_doc_test.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from datetime import datetime
+from openprocurement.api.tests.base import BaseWebTest
+from openprocurement.api.utils.db_state_doc import DBStateDocManager
+
+
+class DBStateDocManagerTestCase(BaseWebTest):
+
+    def setUp(self):
+        super(DBStateDocManagerTestCase, self).setUp()
+        self.docname = 'test_dbstate_doc'
+        self.manager = DBStateDocManager(self.db, doc_name=self.docname)
+
+    def test_create_doc(self):
+        """Create db_state_doc"""
+        self.manager._create_doc()
+
+        db_doc = self.db.get(self.docname)
+        self.assertNotEqual(db_doc, None, 'db_state_doc must be created')
+        created_time = db_doc['db_created']
+        # iso8601 timestring with time value always contains 'T'
+        self.assertIn('T', created_time, 'Invalid timestring')
+        self.assertIn('+00:00', created_time, 'timestamp must be in UTC')
+
+    def test_assure_doc_while_doc_present(self):
+        doc = self.manager._create_doc()
+
+        tstamp_old = doc['db_created']
+
+        self.manager.assure_doc()
+
+        doc_updated = doc.load(self.db, self.docname)
+
+        tstamp_new = doc_updated['db_created']
+        self.assertEqual(
+            tstamp_new.microsecond, tstamp_old.microsecond, 'document should not be changed'
+        )
+
+    def test_write_migration_info(self):
+        target_params = {
+            'name': 'test_name',
+            'description': 'test_descr',
+            'applied': datetime.now().isoformat()
+        }
+        self.manager.write_migration_info(**target_params)
+
+        upd_doc = self.db[self.docname]
+        self.assertTrue(len(upd_doc['migrations']), 1)
+
+    def tearDown(self):
+        dbs_doc = self.db.get(self.docname)
+        if dbs_doc:
+            self.db.delete(dbs_doc)
+
+
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(DBStateDocManagerTestCase))
+    return suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/src/openprocurement/api/tests/utils.py
+++ b/src/openprocurement/api/tests/utils.py
@@ -63,6 +63,7 @@ from openprocurement.api.utils.decorators import (
 from openprocurement.api.utils.documents import (
     generate_docservice_url,
 )
+from openprocurement.api.models.common import DBState
 from openprocurement.api.exceptions import ConfigAliasError
 from openprocurement.api.tests.base import MOCK_CONFIG
 from openprocurement.api.tests.fixtures.config import RANDOM_PLUGINS
@@ -1005,21 +1006,44 @@ class TimeDependentValueTestCase(unittest.TestCase):
         self.assertEqual(value, before)
 
 
+class DBStateTestCase(unittest.TestCase):
+
+    def test_serialize(self):
+        data = {
+            "db_created": "2019-01-01T10:11:01Z",
+            "migrations": [
+                {
+                    "name": "loki_add_related_processes",
+                    "description": "Adds relatedProcess",
+                    "applied": "2019-02-15T17:13:01Z"
+                },
+                {
+                    "name": "rubble_add_smth",
+                    "description": "Adds smth",
+                    "applied": "2019-02-15T17:25:31Z"
+                }
+            ]
+        }
+        m = DBState(data)
+        m.validate()
+
+
 def suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(UtilsTest))
     suite.addTest(unittest.makeSuite(CalculateBusinessDateTestCase))
     suite.addTest(unittest.makeSuite(CallBeforeTestCase))
-    suite.addTest(unittest.makeSuite(TestSearchListWithDicts))
-    suite.addTest(unittest.makeSuite(CreateAppMetaTestCase))
-    suite.addTest(unittest.makeSuite(RunMigrationsConsoleEntrypointTestCase))
-    suite.addTest(unittest.makeSuite(PathToKvTestCase))
     suite.addTest(unittest.makeSuite(CollectPackagesForMigrationTestCase))
+    suite.addTest(unittest.makeSuite(CreateAppMetaTestCase))
+    suite.addTest(unittest.makeSuite(DBStateTestCase))
+    suite.addTest(unittest.makeSuite(PathToKvTestCase))
     suite.addTest(unittest.makeSuite(RoundSecondsToHoursTestCase))
+    suite.addTest(unittest.makeSuite(RunMigrationsConsoleEntrypointTestCase))
     suite.addTest(unittest.makeSuite(SetTimezoneTestCase))
-    suite.addTest(unittest.makeSuite(UtcoffsetIsAliquotToHoursTestCase))
-    suite.addTest(unittest.makeSuite(UtcoffsetDifferenceTestCase))
+    suite.addTest(unittest.makeSuite(TestSearchListWithDicts))
     suite.addTest(unittest.makeSuite(TimeDependentValueTestCase))
+    suite.addTest(unittest.makeSuite(UtcoffsetDifferenceTestCase))
+    suite.addTest(unittest.makeSuite(UtcoffsetIsAliquotToHoursTestCase))
+    suite.addTest(unittest.makeSuite(UtilsTest))
     return suite
 
 

--- a/src/openprocurement/api/utils/db_state_doc.py
+++ b/src/openprocurement/api/utils/db_state_doc.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from pytz import utc
+from openprocurement.api.utils.common import get_now
+from openprocurement.api.constants import DB_STATE_DOC_DEFAULT_NAME
+from openprocurement.api.models.common import DBState, MigrationInfo
+
+
+class DBStateDocManager(object):
+    """Operates on `db state` document"""
+
+    def __init__(self, db, doc_name=DB_STATE_DOC_DEFAULT_NAME):
+        self._db = db
+        self._docname = doc_name
+
+    def _create_doc(self):
+        """Write basic DBState document to the DB"""
+
+        time_to_db = get_now().astimezone(utc)
+
+        doc = DBState({
+            '_id': self._docname,
+            'db_created': time_to_db,
+        })
+        doc.store(self._db)
+
+        return doc
+
+    def assure_doc(self):
+        """Check if db state doc is present and create it if it isn't"""
+
+        doc_present = DBState.load(self._db, self._docname)
+        if not doc_present:
+            return self._create_doc()
+
+    def write_migration_info(self, name, description, applied):
+        """Write migration info to the database"""
+
+        # I decided to do this check mandatory to make use of this manager easy as possible
+        self.assure_doc()
+
+        migration_info = MigrationInfo({
+            'name': name,
+            'description': description,
+            'applied': applied
+        })
+        migration_info.validate()
+        migration_info = migration_info.to_primitive()
+
+        db_state_doc = DBState.load(self._db, self._docname)
+        db_state_doc['migrations'].append(migration_info)
+
+        db_state_doc.store(self._db)


### PR DESCRIPTION
This PR brings `DBState` document addition on DB init. Furthermore, that doc will necessarily contain DB creation time (in UTC). It also planned to hold migrations info there, but it's ain't implemented yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.api/423)
<!-- Reviewable:end -->
