### PR TITLE
Handle zero-valued accelerator value

### DIFF
--- a/src/openprocurement/api/tests/utils/timestuff_tests.py
+++ b/src/openprocurement/api/tests/utils/timestuff_tests.py
@@ -28,6 +28,14 @@ class CalculateBusinessDateTestCase(unittest.TestCase):
         result = calculate_business_date(start, period_to_add, auction)
         self.assertEqual((result - start).days, 1)
 
+    def test_zero_accelerator(self):
+        # auction = auction_mock(procurementMethodDetails='quick, accelerator=1440') # TODO: Fix mocked attr
+        auction = {"procurementMethodDetails": 'quick, accelerator=0'}
+        start = get_now()
+        period_to_add = timedelta(days=0)
+        result = calculate_business_date(start, period_to_add, auction)
+        self.assertEqual((result - start).days, 0)
+
     def test_accelerated_calculation_specific_hour(self):
         # auction = auction_mock(procurementMethodDetails='quick, accelerator=1440') # TODO: Fix mocked attr
         auction = {"procurementMethodDetails": 'quick, accelerator=1440'}

--- a/src/openprocurement/api/utils/timestuff.py
+++ b/src/openprocurement/api/utils/timestuff.py
@@ -139,8 +139,11 @@ def get_accelerator(context):
 def accelerated_calculate_business_date(date, period, accelerator, specific_time=None, specific_hour=None):
     re_obj = ACCELERATOR_RE.search(accelerator)
     if re_obj and 'accelerator' in re_obj.groupdict():
+        accelerator_value = int(re_obj.groupdict()['accelerator'])
         if specific_hour or specific_time:
             period = period + (specific_time_setting(date, specific_time, specific_hour) - date)
+        if accelerator_value == 0:
+            return date + period
         return date + (period / int(re_obj.groupdict()['accelerator']))
 
 


### PR DESCRIPTION
## Суть проблеми

Під час створення процедури на пісочниці можна передати поле `procurementMethodDetails`, а в ньому поставити `accelerator` рівним нулю.
Тоді під час ділення періоду на акселератор виникає помилка операції ділення на нуль.

## Рішення

У випадку нульового акселератора треба просто не змінювати початковий період. Це логічно, і можна не кидати помилку.
Але слід заборонити встановлювати акселератор в значення `(-inf; 0) ∪ (0; 1)`.
Від'ємні значення не мають змісту, а ті, що менші за одиницю під час ділення призведуть до збільшення поточного періоду, що може породити непередбачувані наслідки для системи.

## UPD

регулярка вичитки значення акселератора складена так, що вона сприйме лише цілочисельне невід'ємне ціле значення. Тому валідацію на від'ємне та (0; 1) можна не робити.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.api/438)
<!-- Reviewable:end -->
